### PR TITLE
fix(welcome): gate CLI welcome buttons on actual availability

### DIFF
--- a/src/utils/claude-cli-resolver.ts
+++ b/src/utils/claude-cli-resolver.ts
@@ -27,6 +27,15 @@ const CLAUDE_SEARCH_DIRS = [
 let _claudeDir: string | null = null;
 
 /**
+ * Returns true if the Claude CLI binary can be located (via `which` or one of
+ * the common install directories). Mirrors `isGeminiAvailable`/`isOpenCodeAvailable`/
+ * `isCodexAvailable` in the sibling resolvers.
+ */
+export function isClaudeAvailable(): boolean {
+  return findClaudeDir() !== null;
+}
+
+/**
  * Finds the directory containing the `claude` binary.
  * Checks `which claude` first, then falls back to common install locations.
  * Result is cached for subsequent calls.

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -311,11 +311,11 @@
           <h1 class="welcome-title">Codeman</h1>
           <p class="welcome-desc">Manage AI Coding tools in persistent tmux sessions.</p>
           <div class="welcome-actions">
-            <button class="welcome-btn welcome-btn-claude" onclick="app.setRunMode('claude'); app.runClaude()">
+            <button class="welcome-btn welcome-btn-claude" id="welcomeClaudeBtn" style="display: none;" onclick="app.setRunMode('claude'); app.runClaude()">
               <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="5 3 19 12 5 21 5 3"/></svg>
               Run Claude Code
             </button>
-            <button class="welcome-btn welcome-btn-opencode" onclick="app.setRunMode('opencode'); app.runOpenCode()">
+            <button class="welcome-btn welcome-btn-opencode" id="welcomeOpencodeBtn" style="display: none;" onclick="app.setRunMode('opencode'); app.runOpenCode()">
               <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="5 3 19 12 5 21 5 3"/></svg>
               Run OpenCode
             </button>

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -315,22 +315,14 @@
               <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="5 3 19 12 5 21 5 3"/></svg>
               Run Claude Code
             </button>
-            <button class="welcome-btn welcome-btn-tunnel" id="welcomeTunnelBtn" onclick="app.toggleTunnelFromWelcome()">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg>
-              Cloudflare Tunnel
-            </button>
             <button class="welcome-btn welcome-btn-opencode" onclick="app.setRunMode('opencode'); app.runOpenCode()">
               <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="5 3 19 12 5 21 5 3"/></svg>
               Run OpenCode
             </button>
-            <button class="welcome-btn welcome-btn-gemini" onclick="app.setRunMode('gemini'); app.runGemini()">
+            <button class="welcome-btn welcome-btn-gemini" id="welcomeGeminiBtn" style="display: none;" onclick="app.setRunMode('gemini'); app.runGemini()">
               <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="5 3 19 12 5 21 5 3"/></svg>
               Run Gemini
             </button>
-          </div>
-          <div class="welcome-qr" id="welcomeQr" onclick="app.toggleWelcomeQrSize()">
-            <div class="welcome-qr-inner" id="welcomeQrInner"></div>
-            <div class="welcome-qr-url" id="welcomeQrUrl"></div>
           </div>
           <div class="history-sessions" id="historySessions" style="display:none">
             <div class="search-panel" id="searchPanel">

--- a/src/web/public/settings-ui.js
+++ b/src/web/public/settings-ui.js
@@ -695,10 +695,22 @@ Object.assign(CodemanApp.prototype, {
   },
 
   async loadGeminiAvailability() {
-    const btn = document.getElementById('welcomeGeminiBtn');
+    await this._loadCliAvailability('welcomeGeminiBtn', '/api/gemini/status');
+  },
+
+  async loadClaudeAvailability() {
+    await this._loadCliAvailability('welcomeClaudeBtn', '/api/claude/status');
+  },
+
+  async loadOpencodeAvailability() {
+    await this._loadCliAvailability('welcomeOpencodeBtn', '/api/opencode/status');
+  },
+
+  async _loadCliAvailability(buttonId, statusUrl) {
+    const btn = document.getElementById(buttonId);
     if (!btn) return;
     try {
-      const res = await fetch('/api/gemini/status');
+      const res = await fetch(statusUrl);
       const env = await res.json();
       const status = env?.success === true ? env.data : env;
       btn.style.display = status?.available ? 'flex' : 'none';

--- a/src/web/public/settings-ui.js
+++ b/src/web/public/settings-ui.js
@@ -694,6 +694,19 @@ Object.assign(CodemanApp.prototype, {
     this._updatePollTimer = setInterval(poll, 1500);
   },
 
+  async loadGeminiAvailability() {
+    const btn = document.getElementById('welcomeGeminiBtn');
+    if (!btn) return;
+    try {
+      const res = await fetch('/api/gemini/status');
+      const env = await res.json();
+      const status = env?.success === true ? env.data : env;
+      btn.style.display = status?.available ? 'flex' : 'none';
+    } catch {
+      btn.style.display = 'none';
+    }
+  },
+
   async loadTunnelStatus() {
     try {
       const res = await fetch('/api/tunnel/status');

--- a/src/web/public/terminal-ui.js
+++ b/src/web/public/terminal-ui.js
@@ -1195,6 +1195,7 @@ Object.assign(CodemanApp.prototype, {
     if (overlay) {
       overlay.classList.add('visible');
       this.loadTunnelStatus();
+      this.loadGeminiAvailability();
       this.loadHistorySessions();
       this.initSearchPanel();
     }

--- a/src/web/public/terminal-ui.js
+++ b/src/web/public/terminal-ui.js
@@ -1195,6 +1195,8 @@ Object.assign(CodemanApp.prototype, {
     if (overlay) {
       overlay.classList.add('visible');
       this.loadTunnelStatus();
+      this.loadClaudeAvailability();
+      this.loadOpencodeAvailability();
       this.loadGeminiAvailability();
       this.loadHistorySessions();
       this.initSearchPanel();

--- a/src/web/routes/system-routes.ts
+++ b/src/web/routes/system-routes.ts
@@ -374,8 +374,18 @@ export function registerSystemRoutes(
   });
 
   // ═══════════════════════════════════════════════════════════════
-  // CLI Integrations (OpenCode, Codex, Gemini, Antigravity)
+  // CLI Integrations (Claude, OpenCode, Codex, Gemini, Antigravity)
   // ═══════════════════════════════════════════════════════════════
+
+  // ========== Claude ==========
+
+  app.get('/api/claude/status', async () => {
+    const { isClaudeAvailable, findClaudeDir } = await import('../../utils/claude-cli-resolver.js');
+    return {
+      available: isClaudeAvailable(),
+      path: findClaudeDir(),
+    };
+  });
 
   // ========== OpenCode ==========
 


### PR DESCRIPTION
## Summary
- Drops the always-visible Cloudflare Tunnel welcome button/QR widget — offering it regardless of whether `cloudflared` is installed is a bad default.
- Gates the Claude, Opencode, and Gemini welcome-screen buttons behind a real availability check (`/api/claude/status`, `/api/opencode/status`, `/api/gemini/status`) instead of showing them unconditionally and letting the click fail.
- Adds `isClaudeAvailable()`/`GET /api/claude/status`, mirroring the existing opencode/codex/gemini CLI resolvers — Claude previously had no availability check at all.
- Refactors the availability-check JS into a shared `_loadCliAvailability(buttonId, statusUrl)` helper instead of duplicating the fetch/try-catch per tool.

Run-mode dropdown entries (Opencode/Codex) are intentionally left unconditional here — same class of issue, but a separate follow-up to keep this PR small.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on touched `.ts` files
- [x] `check:frontend-syntax` and `check:public-assets` pass
- [x] Verified `/api/claude/status`, `/api/opencode/status`, `/api/gemini/status` via curl against a throwaway dev server
- [x] Verified welcome-screen button visibility via Playwright: Claude/Opencode buttons visible (installed locally), Gemini button hidden (not installed), no console errors