### PR TITLE
fix(run-mode): gate dropdown entries on CLI availability

### DIFF
--- a/src/utils/claude-cli-resolver.ts
+++ b/src/utils/claude-cli-resolver.ts
@@ -27,6 +27,15 @@ const CLAUDE_SEARCH_DIRS = [
 let _claudeDir: string | null = null;
 
 /**
+ * Returns true if the Claude CLI binary can be located (via `which` or one of
+ * the common install directories). Mirrors `isGeminiAvailable`/`isOpenCodeAvailable`/
+ * `isCodexAvailable` in the sibling resolvers.
+ */
+export function isClaudeAvailable(): boolean {
+  return findClaudeDir() !== null;
+}
+
+/**
  * Finds the directory containing the `claude` binary.
  * Checks `which claude` first, then falls back to common install locations.
  * Result is cached for subsequent calls.

--- a/src/web/public/session-ui.js
+++ b/src/web/public/session-ui.js
@@ -441,6 +441,7 @@ Object.assign(CodemanApp.prototype, {
     // Load history sessions when menu opens
     if (menu.classList.contains('active')) {
       this._loadRunModeHistory();
+      this._refreshRunModeAvailability();
       const close = (ev) => {
         if (!menu.contains(ev.target)) {
           menu.classList.remove('active');
@@ -449,6 +450,32 @@ Object.assign(CodemanApp.prototype, {
       };
       setTimeout(() => document.addEventListener('click', close), 0);
     }
+  },
+
+  /**
+   * Hides run-mode dropdown entries for CLIs that aren't installed, so
+   * picking one doesn't spawn a session that immediately errors out.
+   * Shell has no external CLI dependency and is never gated.
+   */
+  async _refreshRunModeAvailability() {
+    const checks = [
+      ['claude', '/api/claude/status'],
+      ['opencode', '/api/opencode/status'],
+      ['codex', '/api/codex/status'],
+      ['gemini', '/api/gemini/status'],
+    ];
+    await Promise.all(checks.map(async ([mode, url]) => {
+      const btn = document.querySelector(`.run-mode-option[data-mode="${mode}"]`);
+      if (!btn) return;
+      try {
+        const res = await fetch(url);
+        const env = await res.json();
+        const status = env?.success === true ? env.data : env;
+        btn.style.display = status?.available ? 'flex' : 'none';
+      } catch {
+        btn.style.display = 'none';
+      }
+    }));
   },
 
   async _loadRunModeHistory() {

--- a/src/web/routes/system-routes.ts
+++ b/src/web/routes/system-routes.ts
@@ -374,8 +374,18 @@ export function registerSystemRoutes(
   });
 
   // ═══════════════════════════════════════════════════════════════
-  // CLI Integrations (OpenCode, Codex, Gemini, Antigravity)
+  // CLI Integrations (Claude, OpenCode, Codex, Gemini, Antigravity)
   // ═══════════════════════════════════════════════════════════════
+
+  // ========== Claude ==========
+
+  app.get('/api/claude/status', async () => {
+    const { isClaudeAvailable, findClaudeDir } = await import('../../utils/claude-cli-resolver.js');
+    return {
+      available: isClaudeAvailable(),
+      path: findClaudeDir(),
+    };
+  });
 
   // ========== OpenCode ==========
 


### PR DESCRIPTION
## Summary
Follow-up to #200 (welcome-screen buttons). The run-mode dropdown (gear icon next to Run) has the same problem: Claude/Opencode/Codex/Gemini entries are always shown regardless of whether the CLI is actually installed, so picking one can spawn a session that immediately errors out.

- Adds `_refreshRunModeAvailability()` in `session-ui.js`, called each time the dropdown opens; hides an entry whose `/api/<cli>/status` reports `available: false`.
- Shell is intentionally left unconditional — no external CLI dependency.

**Depends on #200**: `isClaudeAvailable()` / `GET /api/claude/status` don't exist on `master` yet, so this branch duplicates that small addition from #200 to stay self-contained and independently reviewable/mergeable. Once #200 lands, this branch should be rebased onto `master`, which will cleanly collapse the duplicate (trivial conflict, or none if git dedupes it).

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on touched `.ts` files
- [x] `check:frontend-syntax` and `check:public-assets` pass
- [x] Verified all four `/api/*/status` endpoints via curl against a throwaway dev server
- [x] Verified dropdown gating via Playwright: claude/opencode/shell visible, codex/gemini hidden (matches local install state), no console errors