### PR TITLE
fix: decode dotdir working directories in history session scanning

### DIFF
--- a/src/web/routes/session-routes.ts
+++ b/src/web/routes/session-routes.ts
@@ -2514,6 +2514,25 @@ export function registerSessionRoutes(
           }
         }
       }
+      // The encoder maps both '/' and '.' to '-', so a literal '.' in the
+      // original path (e.g. "/home/timkjr/.codeman") collapses into an empty
+      // split segment here. Retry this window as a dotdir/dotfile: ".<join>".
+      if (segments[idx] === '' && idx + 1 < segments.length) {
+        const dotMaxLook = Math.min(idx + 1 + 4, segments.length);
+        for (let end = dotMaxLook - 1; end >= idx + 1; end--) {
+          const dotCandidates =
+            end === idx + 1
+              ? [segments[idx + 1]]
+              : [segments.slice(idx + 1, end + 1).join('-'), segments.slice(idx + 1, end + 1).join('_')];
+          for (const child of dotCandidates) {
+            const candidate = current + '/.' + child;
+            if (await isDir(candidate)) {
+              const result = await tryDecode(end + 1, candidate);
+              if (result) return result;
+            }
+          }
+        }
+      }
       return null;
     }
 
@@ -2546,6 +2565,25 @@ export function registerSessionRoutes(
           }
         }
         if (matched) break;
+      }
+      if (!matched && segments[i] === '' && i + 1 < segments.length) {
+        const dotMaxLook = Math.min(i + 1 + 4, segments.length);
+        for (let end = i + 1; end < dotMaxLook; end++) {
+          const dotCandidates =
+            end === i + 1
+              ? [segments[i + 1]]
+              : [segments.slice(i + 1, end + 1).join('_'), segments.slice(i + 1, end + 1).join('-')];
+          for (const child of dotCandidates) {
+            const candidate = current + '/.' + child;
+            if (await isDir(candidate)) {
+              current = candidate;
+              i = end + 1;
+              matched = true;
+              break;
+            }
+          }
+          if (matched) break;
+        }
       }
       if (!matched) {
         current = current + '/' + segments[i];

--- a/test/routes/session-routes.test.ts
+++ b/test/routes/session-routes.test.ts
@@ -18,7 +18,7 @@ import Fastify, { type FastifyInstance } from 'fastify';
 import fastifyCookie from '@fastify/cookie';
 import fastifyMultipart from '@fastify/multipart';
 import { join } from 'node:path';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { createMockRouteContext, type MockRouteContext } from '../mocks/index.js';
 import { installRouteErrorHandler } from '../../src/web/route-error-handler.js';
@@ -1287,6 +1287,39 @@ describe('session-routes', () => {
       });
       const body = JSON.parse(res.body);
       expect(body.data.sessions.length).toBeLessThanOrEqual(50);
+    });
+
+    it('decodes a dotdir working directory (e.g. ~/.codeman) instead of falling back to $HOME', async () => {
+      // Claude Code's project-key encoding maps both '/' and '.' to '-', so
+      // "/home/x/.dotcase" and "/home/x/dotcase" collapse to the same-looking
+      // dash run except for a doubled dash. decodeProjectKey() must still
+      // recover the real (dotdir) path rather than silently falling back to
+      // bare $HOME (COD bug: 2026-08-01, ~/.codeman resumed sessions got
+      // workingDir "/home/timkjr" instead of "/home/timkjr/.codeman").
+      const home = process.env.HOME as string;
+      const realDir = join(home, '.dotcase');
+      await mkdir(realDir, { recursive: true });
+
+      const projectKey = realDir.replace(/\//g, '-').replace(/\./g, '-');
+      const projDir = join(home, '.claude', 'projects', projectKey);
+      await mkdir(projDir, { recursive: true });
+
+      const sessionId = '12345678-1234-1234-1234-123456789012';
+      const transcriptLine = JSON.stringify({ type: 'user', message: { role: 'user', content: 'hello world' } }) + '\n';
+      // scanProjectDir skips files under 4000 bytes.
+      const padding = '#'.repeat(4200 - transcriptLine.length);
+      await writeFile(join(projDir, `${sessionId}.jsonl`), transcriptLine + padding);
+
+      const res = await harness.app.inject({
+        method: 'GET',
+        url: `/api/history/sessions?projectKey=${projectKey}`,
+      });
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body);
+      const row = body.data.sessions.find((s: { sessionId: string }) => s.sessionId === sessionId);
+      expect(row).toBeDefined();
+      expect(row.workingDir).toBe(realDir);
+      expect(row.workingDir).not.toBe(home);
     });
   });
 


### PR DESCRIPTION
## Summary

`decodeProjectKey()` in `src/web/routes/session-routes.ts` (used by `scanProjectDir()` / `GET /api/history/sessions`) reconstructs a session's real working directory from Claude Code's encoded project-key directory name under `~/.claude/projects/`.

Claude Code's encoder maps **both** `/` and `.` to `-`, so a path like `/home/user/.codeman` encodes to `-home-user--codeman`. The existing decoder's candidate-join logic only ever tried joining segments with `-` or `_`, so it could never reconstruct a hidden (dot-prefixed) directory — it would fail to find a match on disk and silently fall back to bare `$HOME`.

In practice this corrupts `workingDir` for any case that lives under a dotdir (`~/.codeman` being the most obvious example, but any project nested under a hidden directory anywhere in its path hits this), for every session resumed through the history/session-picker UI. The wrong `workingDir` then propagates into `state.json` and affects anything that trusts `session.workingDir` (CLAUDE.md lookup, paste-image dir, subagent/image watchers, etc).

## Fix

Added dot-prefixed candidate generation to both the backtracking `tryDecode()` decoder and its greedy fallback loop. A leading empty string produced by `.split('-')` is the signature of a literal `.` in the original path, so that window is retried as `.<join>` (a hidden dir) when the normal join candidates don't match anything on disk.

## Test plan

- [x] `tsc --noEmit` passes
- [x] `eslint` clean on changed files
- [x] New regression test added: `GET /api/history/sessions > decodes a dotdir working directory (e.g. ~/.codeman) instead of falling back to $HOME` — verified it fails without the fix (asserts old buggy value) and passes with it
- [x] Full `test/routes/session-routes.test.ts` + `test/routes/unified-sessions-routes.test.ts` suites pass (85 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)