### PR TITLE
fix(shell): launch shell tabs as an interactive login shell

### DIFF
--- a/src/tmux-manager.ts
+++ b/src/tmux-manager.ts
@@ -780,7 +780,11 @@ export function buildSpawnCommand(options: {
   // SERVER process's env — empty in containers and system systemd units, leaving
   // the pane command ending in a dangling `&&` ("syntax error: unexpected end of
   // file", pane dead on arrival). Resolve it in Node and quote the result.
-  return shellescape(resolveLocalShell());
+  // -i -l: interactive login shell, so the resolved shell sources the user's rc
+  // files (~/.zshrc, ~/.bashrc, etc.) instead of running as a bare non-interactive
+  // child of the non-interactive `bash -c` that launches the pane — without this,
+  // aliases, PATH additions, and tool init (zoxide, nvm, etc.) are silently dropped.
+  return `${shellescape(resolveLocalShell())} -i -l`;
 }
 
 /**

--- a/test/shell-session-launch.test.ts
+++ b/test/shell-session-launch.test.ts
@@ -88,6 +88,14 @@ describe('shell-mode spawn command (issue #208)', () => {
     expect(cmd.trim()).not.toBe('');
   });
 
+  it('launches an interactive login shell, so rc files (~/.zshrc, ~/.bashrc, etc.) are sourced', () => {
+    // Without -i -l, the resolved shell runs as a bare non-interactive child of
+    // the non-interactive `bash -c` that launches the pane, silently dropping
+    // aliases, PATH additions, and tool init (zoxide, nvm, etc.).
+    const cmd = buildSpawnCommand({ mode: 'shell', sessionId: 'abc123de-0000-0000-0000-000000000000' });
+    expect(cmd.trim().endsWith('-i -l')).toBe(true);
+  });
+
   it('produces a launch command that parses after the outer sh -c expansion layer', () => {
     const cmd = buildSpawnCommand({ mode: 'shell', sessionId: 'abc123de-0000-0000-0000-000000000000' });
     // Mirrors tmux-manager: `… bash -c ${JSON.stringify(launchCmd)}` handed to `sh -c`.


### PR DESCRIPTION
## Summary

Follow-up to #208's fix. Shell-mode sessions now resolve to a real absolute shell path (`resolveLocalShell()` in `src/utils/shell-resolver.ts`), but the resolved shell is launched bare — no `-i`/`-l` flags.

Without those flags, the spawned shell runs as a non-interactive child of the non-interactive `bash -c` that launches the pane, so it never sources `~/.zshrc`/`~/.bashrc`. Aliases, PATH additions, and tool init (zoxide, nvm, etc.) are silently dropped — the shell tab "works" but doesn't feel like the user's actual shell.

## Fix

Append `-i -l` to the resolved shell invocation in `buildSpawnCommand`, so it launches as a proper interactive login shell.

## Test plan

- [x] `tsc --noEmit` passes
- [x] Existing `#208` regression tests in `test/shell-session-launch.test.ts` still pass unmodified (they assert "not a bare `$SHELL`" and "parses cleanly", both still true)
- [x] Added a new test asserting the launch command ends in `-i -l`
- [x] `test/tmux-manager.test.ts`, `test/claude-permission-mode.test.ts`, `test/antigravity-mode.test.ts` all pass (76 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)