### PR TITLE
fix(remote-ssh): route shell + agent CLIs through a real interactive login shell

### DIFF
--- a/src/remote-hosts.ts
+++ b/src/remote-hosts.ts
@@ -60,7 +60,11 @@ export async function writeRemoteCases(configDir: string, cases: RemoteCase[]): 
 
 export function defaultRemoteCommandForMode(mode: SessionMode): string {
   const commands: Record<RemoteCommandMode, string> = {
-    shell: 'exec bash -l',
+    // $SHELL, not a hardcoded bash: sshd sets it from the remote user's
+    // /etc/passwd entry, so this launches their actual login shell (zsh,
+    // fish, etc.). -i -l so it sources rc files (~/.zshrc etc.), matching
+    // the local shell-mode launch.
+    shell: 'exec $SHELL -i -l',
     // Mirror the LOCAL claude default so the remote agent runs non-interactively
     // (no trust-folder/permission prompt that nothing on the remote answers). The
     // per-host `commands.claude` override stays the escape hatch.

--- a/src/remote-hosts.ts
+++ b/src/remote-hosts.ts
@@ -59,6 +59,15 @@ export async function writeRemoteCases(configDir: string, cases: RemoteCase[]): 
 }
 
 export function defaultRemoteCommandForMode(mode: SessionMode): string {
+  // Agent CLIs (claude/opencode/codex/gemini/antigravity) are typically installed
+  // under per-user paths like ~/.local/bin or ~/.opencode/bin, added to PATH only by
+  // the remote user's interactive-login shell startup files (~/.zshrc etc.). ssh's
+  // remote-command execution is neither interactive nor login, so a bare `exec
+  // claude` sees only sshd's minimal default PATH and fails with "command not
+  // found" (exit 127) — confirmed via `tmux capture-pane` on the
+  // remain-on-exit-preserved dead pane. Route through `$SHELL -i -l -c`, the same
+  // fix already used for shell mode below, so PATH is fully resolved before the
+  // CLI name is looked up.
   const commands: Record<RemoteCommandMode, string> = {
     // $SHELL, not a hardcoded bash: sshd sets it from the remote user's
     // /etc/passwd entry, so this launches their actual login shell (zsh,
@@ -68,11 +77,11 @@ export function defaultRemoteCommandForMode(mode: SessionMode): string {
     // Mirror the LOCAL claude default so the remote agent runs non-interactively
     // (no trust-folder/permission prompt that nothing on the remote answers). The
     // per-host `commands.claude` override stays the escape hatch.
-    claude: 'exec claude --dangerously-skip-permissions',
-    opencode: 'exec opencode',
-    codex: 'exec codex',
-    gemini: 'exec gemini',
-    antigravity: 'exec agy',
+    claude: `exec $SHELL -i -l -c ${shellescape('claude --dangerously-skip-permissions')}`,
+    opencode: `exec $SHELL -i -l -c ${shellescape('opencode')}`,
+    codex: `exec $SHELL -i -l -c ${shellescape('codex')}`,
+    gemini: `exec $SHELL -i -l -c ${shellescape('gemini')}`,
+    antigravity: `exec $SHELL -i -l -c ${shellescape('agy')}`,
   };
   return commands[mode as RemoteCommandMode] || commands.shell;
 }

--- a/src/tmux-manager.ts
+++ b/src/tmux-manager.ts
@@ -852,13 +852,14 @@ export function buildRemoteLaunchCommand(options: {
   // hardcoding --dangerously-skip-permissions, so a non-granted multi-user user's
   // downgraded 'auto' actually reaches the remote agent (the default command otherwise
   // ignored claudeMode). A per-host `commands.claude` override stays authoritative
-  // (admin's explicit choice). For the DEFAULT single-user config (skip), the emitted
-  // command is byte-identical to before. Non-claude modes are unchanged.
+  // (admin's explicit choice). Wrapped in `$SHELL -i -l -c` for the same reason as
+  // `defaultRemoteCommandForMode`: `claude` lives under a per-user PATH entry that
+  // only an interactive login shell resolves (see that function's comment).
   const override = remote.commands?.[mode];
   const modeCommand = override
     ? override
     : mode === 'claude'
-      ? `exec claude${buildClaudePermissionFlags(claudeMode, allowedTools)}`
+      ? `exec $SHELL -i -l -c ${shellescape(`claude${buildClaudePermissionFlags(claudeMode, allowedTools)}`)}`
       : defaultRemoteCommandForMode(mode);
   const remoteName = remoteTmuxSessionName(sessionId);
 

--- a/src/tmux-manager.ts
+++ b/src/tmux-manager.ts
@@ -873,6 +873,14 @@ export function buildRemoteLaunchCommand(options: {
   // shared remote tmux server's other sessions keep their own prefix/mouse.
   const tmuxInvocation = [
     `tmux -L ${REMOTE_TMUX_SOCKET} new-session -A -s ${remoteName} -c ${shellescape(remote.remotePath)} ${shellescape(paneCommand)}`,
+    // Without this, tmux's default behavior destroys the pane -> window ->
+    // session (and, being the only session, the whole remote server) the
+    // instant paneCommand exits for ANY reason -- even something transient.
+    // That tears down the local ssh -t attach along with it (dead pane,
+    // status whatever ssh reported), and reconnect's `-A` then creates a
+    // fresh session with no trace of what actually happened. Set first, so
+    // it applies as early as possible after the pane starts.
+    `set -t ${remoteName} remain-on-exit on`,
     `set -t ${remoteName} status off`,
     `set -t ${remoteName} mouse off`,
     `set -t ${remoteName} prefix C-q`,

--- a/test/antigravity-mode.test.ts
+++ b/test/antigravity-mode.test.ts
@@ -118,6 +118,8 @@ describe('Antigravity mode gates', () => {
 
   it('has docker/remote default commands', () => {
     expect(defaultDockerCommandForMode('antigravity')).toBe('exec agy');
-    expect(defaultRemoteCommandForMode('antigravity')).toBe('exec agy');
+    // Routed through an interactive login shell so per-user PATH entries resolve —
+    // same fix as the other remote agent CLIs (see defaultRemoteCommandForMode).
+    expect(defaultRemoteCommandForMode('antigravity')).toBe("exec $SHELL -i -l -c 'agy'");
   });
 });

--- a/test/remote-hosts.test.ts
+++ b/test/remote-hosts.test.ts
@@ -55,7 +55,7 @@ describe('remote-hosts domain', () => {
   });
 
   it('returns safe mode defaults and remote display values', () => {
-    expect(defaultRemoteCommandForMode('shell')).toBe('exec bash -l');
+    expect(defaultRemoteCommandForMode('shell')).toBe('exec $SHELL -i -l');
     expect(defaultRemoteCommandForMode('codex')).toBe('exec codex');
     // Mirrors the local claude default so the remote agent runs non-interactively.
     expect(defaultRemoteCommandForMode('claude')).toBe('exec claude --dangerously-skip-permissions');

--- a/test/remote-hosts.test.ts
+++ b/test/remote-hosts.test.ts
@@ -56,9 +56,12 @@ describe('remote-hosts domain', () => {
 
   it('returns safe mode defaults and remote display values', () => {
     expect(defaultRemoteCommandForMode('shell')).toBe('exec $SHELL -i -l');
-    expect(defaultRemoteCommandForMode('codex')).toBe('exec codex');
+    // Routed through an interactive login shell so per-user PATH entries (e.g.
+    // ~/.local/bin, ~/.opencode/bin) resolve — a bare `exec codex` sees only
+    // sshd's minimal default PATH and fails with "command not found".
+    expect(defaultRemoteCommandForMode('codex')).toBe("exec $SHELL -i -l -c 'codex'");
     // Mirrors the local claude default so the remote agent runs non-interactively.
-    expect(defaultRemoteCommandForMode('claude')).toBe('exec claude --dangerously-skip-permissions');
+    expect(defaultRemoteCommandForMode('claude')).toBe("exec $SHELL -i -l -c 'claude --dangerously-skip-permissions'");
     expect(remoteSshTarget({ id: 'h1', label: 'H1', host: 'box.local', username: 'aamer' })).toBe('aamer@box.local');
     expect(remoteDisplayPath({ username: 'aamer', host: 'box.local', path: '/opt/work' })).toBe(
       'aamer@box.local:/opt/work'

--- a/test/remote-ssh-options.test.ts
+++ b/test/remote-ssh-options.test.ts
@@ -150,9 +150,10 @@ describe('COD-107 buildRemoteLaunchCommand — threads connection args', () => {
     const sh = (s: string) => "'" + s.replace(/'/g, "'\\''") + "'";
     const remoteName = `codeman-ssh-${SESSION_ID.slice(0, 8)}`;
     const path = sh('/home/ubuntu/work');
-    const paneCommand = `cd ${path} && exec bash -l`;
+    const paneCommand = `cd ${path} && exec $SHELL -i -l`;
     const tmuxInvocation = [
       `tmux -L codeman-remote new-session -A -s ${remoteName} -c ${path} ${sh(paneCommand)}`,
+      `set -t ${remoteName} remain-on-exit on`,
       `set -t ${remoteName} status off`,
       `set -t ${remoteName} mouse off`,
       `set -t ${remoteName} prefix C-q`,

--- a/test/tmux-manager.test.ts
+++ b/test/tmux-manager.test.ts
@@ -137,7 +137,8 @@ describe('TmuxManager (unit)', () => {
         sessionId: 'abc123def456',
       });
 
-      expect(command).toContain('exec bash -l');
+      expect(command).toContain('exec $SHELL -i -l');
+      expect(command).toContain('remain-on-exit on');
     });
 
     it('defaults claude to a non-interactive launch (--dangerously-skip-permissions)', () => {

--- a/test/tmux-manager.test.ts
+++ b/test/tmux-manager.test.ts
@@ -147,7 +147,13 @@ describe('TmuxManager (unit)', () => {
         remote: { hostId: 'gpu-box', label: 'GPU Box', host: '10.0.0.42', username: 'ubuntu', remotePath: '/w' },
         sessionId: 'abc123def456',
       });
-      expect(command).toContain('exec claude --dangerously-skip-permissions');
+      // Routed through an interactive login shell so ~/.local/bin (where `claude`
+      // typically lives) is on PATH — ssh's remote-command execution is neither
+      // interactive nor login, so a bare `exec claude` fails with "command not found".
+      // The inner quoting is escaped twice over (once per shellescape() layer), so
+      // assert on the unescaped substrings rather than the literal quoted form.
+      expect(command).toContain('exec $SHELL -i -l -c');
+      expect(command).toContain('claude --dangerously-skip-permissions');
     });
   });
 


### PR DESCRIPTION
## Summary

Remote SSH shell/agent-CLI sessions weren't reaching the remote user's real environment, for two separate reasons:

**1. Shell mode hardcoded `exec bash -l`**, ignoring the remote user's actual login shell. sshd sets `$SHELL` from the remote user's `/etc/passwd` entry, so this should launch their real shell (zsh, fish, etc.), not always bash.

**2. `remain-on-exit` was only ever set on the local tmux socket.** If the remote pane command exited for any reason — even something transient — tmux destroyed the pane, window, and (being the only session) the whole remote server, tearing the local `ssh -t` attach down with it and leaving no trace to diagnose. Reconnect's `-A` then created a fresh session, which could repeat as a flap loop with no evidence surviving between attempts.

**3. Once `remain-on-exit` revealed the dead panes**, the real underlying failure became visible: `exec claude`/`exec opencode`/etc. run under ssh's non-interactive, non-login remote-command shell, which only sees sshd's minimal default PATH — not the `~/.zshrc` PATH entries where these CLIs actually live (e.g. `~/.local/bin`, `~/.opencode/bin`). They were silently failing with "command not found" (exit 127).

## Fix (two commits)

1. `shell: 'exec $SHELL -i -l'` instead of hardcoded bash; add `remain-on-exit on` to the remote tmux session's `set` options.
2. Route `claude`/`opencode`/`codex`/`gemini`/`antigravity` through `$SHELL -i -l -c '<cmd>'` too, so PATH is fully resolved before the CLI name is looked up — mirroring the shell-mode fix.

## Test plan

- [x] `tsc --noEmit` passes
- [x] Updated existing assertions in `test/remote-hosts.test.ts`, `test/remote-ssh-options.test.ts`, `test/tmux-manager.test.ts`, `test/antigravity-mode.test.ts` for the new default commands (81 tests pass)
- [x] Per-host `commands.*` override fixtures (e.g. `aaDesktop`, `remote-shared-sessions.test.ts`) deliberately left untouched — they test the override escape hatch, not the default
- [x] Docker-mode default commands (`defaultDockerCommandForMode`) confirmed unaffected — separate function, separate concern

🤖 Generated with [Claude Code](https://claude.com/claude-code)