### PR TITLE
fix(mobile): route terminal taps without breaking keyboard focus

### DIFF
--- a/src/web/public/terminal-ui.js
+++ b/src/web/public/terminal-ui.js
@@ -653,6 +653,7 @@ Object.assign(CodemanApp.prototype, {
       let didScroll = false; // track whether touchmove fired (tap vs scroll)
       let touchStartY = 0;
       let tapStartedWithTerminalFocus = false;
+      let tapStartIntentCache = null;
       const TAP_THRESHOLD = 8; // px — ignore micro-drift to distinguish tap from scroll
       container.addEventListener(
         'touchstart',
@@ -666,11 +667,24 @@ Object.assign(CodemanApp.prototype, {
             isTouching = true;
             didScroll = false;
             tapStartedWithTerminalFocus = this._isMobileTerminalInputFocused();
+            // Classifying scans the whole viewport with translateToString, and
+            // this runs at the start of EVERY gesture including scroll drags.
+            // Cache the result for the touchend of this same gesture rather than
+            // recomputing it; the cache is keyed on the exact start coordinates
+            // so a finger that moved re-classifies at its real position.
             const touchStartIntent = this._classifyMobileTerminalTap(touchLastX, touchLastY);
-            if (touchStartIntent !== 'input') {
+            tapStartIntentCache = { x: touchLastX, y: touchLastY, intent: touchStartIntent };
+            if (touchStartIntent === 'content') {
               // Cancel xterm/browser focus before the compatibility click can
               // open the OS keyboard. Content taps are re-emitted as SGR on
-              // touchend; history taps deliberately remain inert.
+              // touchend.
+              //
+              // 'history' is deliberately NOT included. A scrolled-up viewport
+              // sends nothing, so there is no compatibility click worth
+              // cancelling — and preventDefault() here, paired with touchend's
+              // early return, closes both routes to focus at once. Since
+              // selectSession() ends with scrollToLastNonEmptyLine(), that made
+              // the keyboard unreachable after every tab switch.
               ev.preventDefault();
               this._blurMobileTerminalInput();
             }
@@ -700,7 +714,6 @@ Object.assign(CodemanApp.prototype, {
             // fling, so a jittery tap would both position the cursor AND scroll.
             if (!didScroll) return;
             ev.preventDefault();
-            touchLastX = ev.touches[0].clientX;
             const delta = touchLastY - touchY; // positive = scroll down
             pixelAccum += delta;
             velocity = delta * 1.2;
@@ -737,7 +750,13 @@ Object.assign(CodemanApp.prototype, {
             const touch = ev.changedTouches && ev.changedTouches[0];
             if (touch) {
               this._suppressTrustedTapMouseEvents();
-              this._handleMobileTerminalTap(touch, tapStartedWithTerminalFocus);
+              const cached =
+                tapStartIntentCache &&
+                tapStartIntentCache.x === touch.clientX &&
+                tapStartIntentCache.y === touch.clientY
+                  ? tapStartIntentCache.intent
+                  : null;
+              this._handleMobileTerminalTap(touch, tapStartedWithTerminalFocus, cached);
             }
           }
           tapStartedWithTerminalFocus = false;
@@ -3371,9 +3390,6 @@ Object.assign(CodemanApp.prototype, {
     const mouseTrackingOn = !!mouseMode && mouseMode !== 'none';
     if (!mouseTrackingOn && !this._sessionUsesServerMouseStrip()) return 'input';
 
-    // Permission/elicitation prompts own the full live terminal until answered.
-    if (document.body?.classList?.contains('terminal-action-pending')) return 'content';
-
     const buffer = this.terminal.buffer?.active;
     if (!buffer?.getLine) return 'input';
 
@@ -3421,10 +3437,13 @@ Object.assign(CodemanApp.prototype, {
     let logicalLineEnd = tappedRow;
     while (logicalLineEnd + 1 < rows && wrappedRows[logicalLineEnd + 1]) logicalLineEnd++;
     const tappedLine = lines.slice(logicalLineStart, logicalLineEnd + 1).join('');
-    if (
-      mode === 'claude' &&
-      /^\s*[•·]\s*Working\b.*(?:background|esc to interrupt)/i.test(tappedLine)
-    ) {
+    // Claude's status row is TUI-owned: tapping it opens the teammate view, so it
+    // must not be treated as a keyboard target. Match the AFFORDANCE, not the
+    // wording — the bullet and verb are both unstable (claude 2.1.226 prints
+    // "✻ Cooked for 2m 6s", "✻ Baked for 9m 47s"; earlier builds printed
+    // "• Working …"), while "esc to interrupt" / "background" are what make the
+    // row actionable in the first place.
+    if (mode === 'claude' && /\b(?:esc to interrupt|background)\b/i.test(tappedLine)) {
       return 'content';
     }
     if (menuSelectionVisible) return 'content';
@@ -3471,8 +3490,6 @@ Object.assign(CodemanApp.prototype, {
    * otherwise focus xterm, so focus has to be restored explicitly.
    */
   _isActionableMobileTerminalTap(clientX, clientY) {
-    if (document.body?.classList?.contains('terminal-action-pending')) return true;
-
     const pos = this._clientPointToCell(clientX, clientY);
     const buffer = this.terminal?.buffer?.active;
     if (!pos || !buffer?.getLine) return false;
@@ -3502,14 +3519,22 @@ Object.assign(CodemanApp.prototype, {
     // The hint sits on its own row, so a readback's TITLE row — the one a
     // finger actually lands on — carries no affordance text itself. Look at the
     // adjacent row too, which is how these blocks are laid out in practice.
+    // Keyed on the ACTION VERB, and deliberately not on prose verbs. A CLI hint
+    // names a key or a gesture ("ctrl+r to expand", "tap to collapse",
+    // "esc to interrupt"); "click here to open the file" is transcript content
+    // and must keep the keyboard, so `click` and bare `here` are excluded.
+    // The hint may sit mid-line — Claude's status row is
+    // "✻ Cooked for 2m 6s · esc to interrupt" — so this is not anchored.
     const affordance =
-      /\b(?:ctrl\+\w+|tap|click|enter|esc)\b[^.]{0,24}\bto\s+(?:expand|collapse|view|open|interrupt|see)\b/i;
+      /\b(?:ctrl\+\w+|shift\+\w+|esc|enter|tab|tap)\s+to\s+(?:expand|collapse|view|open|interrupt|see)\b/i;
     const blockStart = Math.max(0, logicalLineStart - 1);
     const blockEnd = Math.min(rows - 1, logicalLineEnd + 1);
     for (let row = blockStart; row <= blockEnd; row++) {
       if (affordance.test(lines[row])) return true;
     }
-    if (/^\s*[•·]\s*Working\b/i.test(tappedLine)) return true;
+    // A Claude status row ("✻ Cooked for 2m 6s · esc to interrupt") is caught by
+    // the affordance above; there is deliberately no verb literal here, because
+    // the verb is randomised per build.
 
     const hasMenuPrompt = lines.some((line) => /^\s*[❯›]\s+\d+[.)]\s/.test(line));
     const hasMenuChoice = lines.some((line) => /^\s+\d+[.)]\s/.test(line));
@@ -3526,11 +3551,20 @@ Object.assign(CodemanApp.prototype, {
     }
   },
 
-  _handleMobileTerminalTap(touch, startedWithTerminalFocus) {
-    if (!touch || !this.terminal) return 'history';
-    const intent = this._classifyMobileTerminalTap(touch.clientX, touch.clientY);
+  _handleMobileTerminalTap(touch, startedWithTerminalFocus, cachedIntent = null) {
+    // A guard bail-out, not a classification: there is nothing to classify. It is
+    // deliberately NOT 'history', which would claim the viewport was scrolled up.
+    if (!touch || !this.terminal) return null;
+    // touchstart already classified this exact point; reuse it rather than paying
+    // a second full-viewport scan for the same gesture.
+    const intent = cachedIntent ?? this._classifyMobileTerminalTap(touch.clientX, touch.clientY);
     if (intent === 'history') {
-      this._blurMobileTerminalInput();
+      // Scrolled up: send NO mouse report — a tap on old output must not be
+      // delivered to the CLI as a click on whatever row now occupies that cell.
+      // Focus is a separate question, and the answer is yes: the user tapped the
+      // terminal, so let them type. Blurring here stranded activeElement on
+      // <body> with no way back to the keyboard.
+      this._focusMobileTerminalInput();
       return intent;
     }
 
@@ -3738,15 +3772,6 @@ Object.assign(CodemanApp.prototype, {
     // plain wheel's target and its input box fixed in place; local scrollback is
     // still on Shift+wheel and on the "Wheel scrolls local history" opt-out above.
     return true;
-  },
-
-  // Claude keeps most transcript history inside its own TUI rather than xterm
-  // scrollback. On verified versions, route a touch drag through the same SGR
-  // wheel path as desktop. Codex keeps the existing local touch behavior.
-  _shouldForwardTouchScrollToApp() {
-    const session = this.sessions?.get(this.activeSessionId);
-    if (session?.mode !== 'claude') return false;
-    return this._shouldForwardWheelToApp({ shiftKey: false });
   },
 
   // Encode wheel ticks as SGR reports (button 64 = up, 65 = down) at the pointer

--- a/src/web/public/terminal-ui.js
+++ b/src/web/public/terminal-ui.js
@@ -664,6 +664,14 @@ Object.assign(CodemanApp.prototype, {
             isTouching = true;
             didScroll = false;
             tapStartedWithTerminalFocus = this._isMobileTerminalInputFocused();
+            const touchStartIntent = this._classifyMobileTerminalTap(touchLastX, touchLastY);
+            if (touchStartIntent !== 'input') {
+              // Cancel xterm/browser focus before the compatibility click can
+              // open the OS keyboard. Content taps are re-emitted as SGR on
+              // touchend; history taps deliberately remain inert.
+              ev.preventDefault();
+              this._blurMobileTerminalInput();
+            }
             lastTime = 0;
             if (scrollFrame) {
               cancelAnimationFrame(scrollFrame);
@@ -671,7 +679,7 @@ Object.assign(CodemanApp.prototype, {
             }
           }
         },
-        { passive: true }
+        { passive: false }
       );
 
       container.addEventListener(
@@ -690,6 +698,7 @@ Object.assign(CodemanApp.prototype, {
             // fling, so a jittery tap would both position the cursor AND scroll.
             if (!didScroll) return;
             ev.preventDefault();
+            touchLastX = ev.touches[0].clientX;
             const delta = touchLastY - touchY; // positive = scroll down
             pixelAccum += delta;
             velocity = delta * 1.2;
@@ -3368,11 +3377,13 @@ Object.assign(CodemanApp.prototype, {
 
     const rows = Math.max(1, this.terminal.rows || 1);
     const lines = [];
+    const wrappedRows = [];
     let hasVisibleContent = false;
     for (let row = 0; row < rows; row++) {
       const line = buffer.getLine(buffer.viewportY + row);
       const text = line?.translateToString?.(true) || '';
       lines.push(text);
+      wrappedRows.push(Boolean(line?.isWrapped));
       if (text.trim()) hasVisibleContent = true;
     }
     if (!hasVisibleContent) return 'input';
@@ -3403,6 +3414,17 @@ Object.assign(CodemanApp.prototype, {
     }
 
     const tappedRow = pos.row - 1;
+    let logicalLineStart = tappedRow;
+    while (logicalLineStart > 0 && wrappedRows[logicalLineStart]) logicalLineStart--;
+    let logicalLineEnd = tappedRow;
+    while (logicalLineEnd + 1 < rows && wrappedRows[logicalLineEnd + 1]) logicalLineEnd++;
+    const tappedLine = lines.slice(logicalLineStart, logicalLineEnd + 1).join('');
+    if (
+      mode === 'claude' &&
+      /^\s*[•·]\s*Working\b.*(?:background|esc to interrupt)/i.test(tappedLine)
+    ) {
+      return 'content';
+    }
     if (menuSelectionVisible) return 'content';
     if (promptRow >= 0) {
       const inputEnd = cursorRow >= promptRow ? cursorRow : promptRow;
@@ -3650,6 +3672,15 @@ Object.assign(CodemanApp.prototype, {
     // plain wheel's target and its input box fixed in place; local scrollback is
     // still on Shift+wheel and on the "Wheel scrolls local history" opt-out above.
     return true;
+  },
+
+  // Claude keeps most transcript history inside its own TUI rather than xterm
+  // scrollback. On verified versions, route a touch drag through the same SGR
+  // wheel path as desktop. Codex keeps the existing local touch behavior.
+  _shouldForwardTouchScrollToApp() {
+    const session = this.sessions?.get(this.activeSessionId);
+    if (session?.mode !== 'claude') return false;
+    return this._shouldForwardWheelToApp({ shiftKey: false });
   },
 
   // Encode wheel ticks as SGR reports (button 64 = up, 65 = down) at the pointer

--- a/src/web/public/terminal-ui.js
+++ b/src/web/public/terminal-ui.js
@@ -650,7 +650,7 @@ Object.assign(CodemanApp.prototype, {
 
       let didScroll = false; // track whether touchmove fired (tap vs scroll)
       let touchStartY = 0;
-      let tapCanActivateTerminal = false;
+      let tapStartedWithTerminalFocus = false;
       const TAP_THRESHOLD = 8; // px — ignore micro-drift to distinguish tap from scroll
       container.addEventListener(
         'touchstart',
@@ -663,7 +663,7 @@ Object.assign(CodemanApp.prototype, {
             pixelAccum = 0;
             isTouching = true;
             didScroll = false;
-            tapCanActivateTerminal = this._shouldForwardMobileTapToApp();
+            tapStartedWithTerminalFocus = this._isMobileTerminalInputFocused();
             lastTime = 0;
             if (scrollFrame) {
               cancelAnimationFrame(scrollFrame);
@@ -723,49 +723,13 @@ Object.assign(CodemanApp.prototype, {
             scrollFrame = requestAnimationFrame(scrollLoop);
           }
           if (!didScroll && this.terminal) {
-            // ── Tap-to-position cursor ──────────────────────────────────
-            // Synthesize a click from the real touch point so the foreground app
-            // moves its cursor to the tapped cell (iOS doesn't reliably do this
-            // itself under touch-action:none). CRITICAL: only when mouse tracking
-            // is ON. xterm disables its local SelectionService while mouse events
-            // are active, so the synthetic click is forwarded to the PTY as an SGR
-            // report (cursor moves). But when tracking is OFF, that same click
-            // drives xterm's LOCAL selection (detail 1/2/3 → char/word/line) — a
-            // tap on CJK text would select & copy it instead of positioning. So
-            // gate strictly on the live mouse-tracking mode.
             const touch = ev.changedTouches && ev.changedTouches[0];
-            const mouseMode = this.terminal.modes?.mouseTrackingMode;
-            const mouseTrackingOn = !!mouseMode && mouseMode !== 'none';
             if (touch) {
               this._suppressTrustedTapMouseEvents();
-            }
-            if (touch && tapCanActivateTerminal && mouseTrackingOn) {
-              this._dispatchSyntheticTerminalClick(touch.clientX, touch.clientY);
-            } else if (
-              touch &&
-              tapCanActivateTerminal &&
-              this._sessionUsesServerMouseStrip()
-            ) {
-              // The server strips mouse-tracking DECSETs from claude/codex/gemini
-              // output (isAltScreenStripMode, session.ts) so the wheel keeps
-              // scrolling scrollback — which leaves THIS xterm permanently at
-              // mouseTrackingMode 'none' even though the TUI on the PTY side has
-              // tracking ON and still understands SGR reports. Encode the report
-              // ourselves and send it straight to the PTY: no DOM click is
-              // dispatched, so xterm's local selection can't trigger either.
-              this._sendSyntheticSgrTap(touch.clientX, touch.clientY);
-            }
-            this._syncMobileHelperTextareaToCursor();
-            // Route subsequent typing to the right place: keep the CJK input
-            // field focused when Chinese input is on, otherwise the terminal.
-            const cjkInput = document.getElementById('cjkInput');
-            if (cjkInput?.classList.contains('cjk-input-visible')) {
-              cjkInput.focus();
-            } else {
-              this.terminal.focus();
+              this._handleMobileTerminalTap(touch, tapStartedWithTerminalFocus);
             }
           }
-          tapCanActivateTerminal = false;
+          tapStartedWithTerminalFocus = false;
         },
         { passive: true }
       );
@@ -776,6 +740,7 @@ Object.assign(CodemanApp.prototype, {
           isTouching = false;
           velocity = 0;
           pixelAccum = 0;
+          tapStartedWithTerminalFocus = false;
         },
         { passive: true }
       );
@@ -3370,24 +3335,138 @@ Object.assign(CodemanApp.prototype, {
     } catch {}
   },
 
-  /**
-   * A tap that opens the phone keyboard is focus-only. Forwarding that same
-   * gesture as a mouse click would activate the highlighted CLI menu option.
-   * Once the keyboard and terminal input were already active at touchstart,
-   * later taps may intentionally position the cursor or select a TUI row.
-   */
-  _shouldForwardMobileTapToApp() {
-    const keyboardVisible =
-      (typeof KeyboardHandler !== 'undefined' && KeyboardHandler.keyboardVisible) ||
-      document.body?.classList?.contains('keyboard-visible');
-    if (!keyboardVisible) return false;
-
+  _isMobileTerminalInputFocused() {
     const active = document.activeElement;
     return (
       active === this.terminal?.textarea ||
       active?.classList?.contains('xterm-helper-textarea') ||
       active?.id === 'cjkInput'
     );
+  },
+
+  /**
+   * Separate terminal input from TUI-owned content on touch devices. A hidden
+   * keyboard must not consume taps on expandable readbacks, tool results, or
+   * decision rows; those taps belong to the foreground CLI. The visible prompt
+   * row remains the deliberate keyboard target.
+   */
+  _classifyMobileTerminalTap(clientX, clientY) {
+    if (!this._terminalViewportAtBottom()) return 'history';
+
+    const pos = this._clientPointToCell(clientX, clientY);
+    if (!pos || !this.terminal) return 'input';
+
+    const mouseMode = this.terminal.modes?.mouseTrackingMode;
+    const mouseTrackingOn = !!mouseMode && mouseMode !== 'none';
+    if (!mouseTrackingOn && !this._sessionUsesServerMouseStrip()) return 'input';
+
+    // Permission/elicitation prompts own the full live terminal until answered.
+    if (document.body?.classList?.contains('terminal-action-pending')) return 'content';
+
+    const buffer = this.terminal.buffer?.active;
+    if (!buffer?.getLine) return 'input';
+
+    const rows = Math.max(1, this.terminal.rows || 1);
+    const lines = [];
+    let hasVisibleContent = false;
+    for (let row = 0; row < rows; row++) {
+      const line = buffer.getLine(buffer.viewportY + row);
+      const text = line?.translateToString?.(true) || '';
+      lines.push(text);
+      if (text.trim()) hasVisibleContent = true;
+    }
+    if (!hasVisibleContent) return 'input';
+
+    const cursorRow = Math.max(0, Math.min(rows - 1, buffer.cursorY || 0));
+    const mode = this.sessions?.get(this.activeSessionId)?.mode || 'claude';
+    let promptRow = -1;
+    let menuSelectionVisible = false;
+
+    if (mode === 'opencode') {
+      if (lines[cursorRow]?.includes('\u2503')) promptRow = cursorRow;
+    } else {
+      for (let row = rows - 1; row >= 0; row--) {
+        const promptMatch = lines[row].match(/^\s*[❯›]/);
+        if (!promptMatch) continue;
+        const tail = lines[row].slice(promptMatch[0].length).trim();
+        // A highlighted numbered choice is a menu row, not an editable prompt.
+        const hasSiblingChoice = lines.some(
+          (line, choiceRow) => choiceRow !== row && /^\s+\d+[.)]\s/.test(line)
+        );
+        if (/^\d+[.)]\s/.test(tail) && hasSiblingChoice) {
+          menuSelectionVisible = true;
+          break;
+        }
+        promptRow = row;
+        break;
+      }
+    }
+
+    const tappedRow = pos.row - 1;
+    if (menuSelectionVisible) return 'content';
+    if (promptRow >= 0) {
+      const inputEnd = cursorRow >= promptRow ? cursorRow : promptRow;
+      if (tappedRow >= promptRow && tappedRow <= inputEnd) return 'input';
+    } else if (tappedRow === cursorRow && cursorRow >= rows - 3) {
+      // During redraws a CLI can temporarily omit its prompt marker. Keep the
+      // live cursor row usable without turning arbitrary transcript rows into
+      // keyboard targets.
+      return 'input';
+    }
+
+    return 'content';
+  },
+
+  _blurMobileTerminalInput() {
+    const active = document.activeElement;
+    if (
+      active === this.terminal?.textarea ||
+      active?.classList?.contains('xterm-helper-textarea') ||
+      active?.id === 'cjkInput'
+    ) {
+      active.blur?.();
+    }
+  },
+
+  _focusMobileTerminalInput() {
+    this._syncMobileHelperTextareaToCursor();
+    const cjkInput = document.getElementById('cjkInput');
+    if (cjkInput?.classList.contains('cjk-input-visible')) {
+      cjkInput.focus();
+    } else {
+      this.terminal?.focus();
+    }
+  },
+
+  _handleMobileTerminalTap(touch, startedWithTerminalFocus) {
+    if (!touch || !this.terminal) return 'history';
+    const intent = this._classifyMobileTerminalTap(touch.clientX, touch.clientY);
+    if (intent === 'history') {
+      this._blurMobileTerminalInput();
+      return intent;
+    }
+
+    const mouseMode = this.terminal.modes?.mouseTrackingMode;
+    const mouseTrackingOn = !!mouseMode && mouseMode !== 'none';
+    const shouldActivate = intent === 'content' || startedWithTerminalFocus;
+    if (shouldActivate && mouseTrackingOn) {
+      // xterm's mouse encoder owns live DECSET modes. The synthetic DOM click
+      // follows the same path as a desktop click.
+      this._dispatchSyntheticTerminalClick(touch.clientX, touch.clientY);
+    } else if (shouldActivate && this._sessionUsesServerMouseStrip()) {
+      // Claude/Codex/Gemini DECSETs are stripped from the browser stream, so
+      // report directly to the PTY while retaining local touch scrollback.
+      this._sendSyntheticSgrTap(touch.clientX, touch.clientY);
+    }
+
+    if (intent === 'content') {
+      // A synthetic xterm click can focus its helper textarea. Blur after the
+      // report so collapsing a readback never opens or retains the keyboard.
+      this._blurMobileTerminalInput();
+    } else {
+      this._focusMobileTerminalInput();
+    }
+    return intent;
   },
 
   // ═══════════════════════════════════════════════════════════════

--- a/src/web/public/terminal-ui.js
+++ b/src/web/public/terminal-ui.js
@@ -3462,6 +3462,60 @@ Object.assign(CodemanApp.prototype, {
     }
   },
 
+  /**
+   * Which 'content' taps should DISMISS the mobile keyboard. Expandable
+   * readbacks, tool results and decision rows are TUI-owned: tapping them acts
+   * on the CLI, so popping the keyboard there is wrong. An inert transcript row
+   * still sends its mouse report, but must keep the keyboard reachable —
+   * touchstart's preventDefault cancels the compatibility click that would
+   * otherwise focus xterm, so focus has to be restored explicitly.
+   */
+  _isActionableMobileTerminalTap(clientX, clientY) {
+    if (document.body?.classList?.contains('terminal-action-pending')) return true;
+
+    const pos = this._clientPointToCell(clientX, clientY);
+    const buffer = this.terminal?.buffer?.active;
+    if (!pos || !buffer?.getLine) return false;
+
+    const rows = Math.max(1, this.terminal.rows || 1);
+    const lines = [];
+    const wrappedRows = [];
+    for (let row = 0; row < rows; row++) {
+      const line = buffer.getLine(buffer.viewportY + row);
+      lines.push(line?.translateToString?.(true) || '');
+      wrappedRows.push(Boolean(line?.isWrapped));
+    }
+
+    const tappedRow = pos.row - 1;
+    let logicalLineStart = tappedRow;
+    while (logicalLineStart > 0 && wrappedRows[logicalLineStart]) logicalLineStart--;
+    let logicalLineEnd = tappedRow;
+    while (logicalLineEnd + 1 < rows && wrappedRows[logicalLineEnd + 1]) logicalLineEnd++;
+    const tappedLine = lines.slice(logicalLineStart, logicalLineEnd + 1).join('');
+
+    // Match the AFFORDANCE a CLI prints, not the row's title text: an
+    // expandable readback, tool result or status row advertises how to act on
+    // it ("ctrl+r to expand", "tap to collapse", "esc to interrupt"). Keying on
+    // titles instead would only recognise the exact strings a fixture happens
+    // to use, and would let a real readback keep the keyboard open.
+    //
+    // The hint sits on its own row, so a readback's TITLE row — the one a
+    // finger actually lands on — carries no affordance text itself. Look at the
+    // adjacent row too, which is how these blocks are laid out in practice.
+    const affordance =
+      /\b(?:ctrl\+\w+|tap|click|enter|esc)\b[^.]{0,24}\bto\s+(?:expand|collapse|view|open|interrupt|see)\b/i;
+    const blockStart = Math.max(0, logicalLineStart - 1);
+    const blockEnd = Math.min(rows - 1, logicalLineEnd + 1);
+    for (let row = blockStart; row <= blockEnd; row++) {
+      if (affordance.test(lines[row])) return true;
+    }
+    if (/^\s*[•·]\s*Working\b/i.test(tappedLine)) return true;
+
+    const hasMenuPrompt = lines.some((line) => /^\s*[❯›]\s+\d+[.)]\s/.test(line));
+    const hasMenuChoice = lines.some((line) => /^\s+\d+[.)]\s/.test(line));
+    return hasMenuPrompt && hasMenuChoice;
+  },
+
   _focusMobileTerminalInput() {
     this._syncMobileHelperTextareaToCursor();
     const cjkInput = document.getElementById('cjkInput');
@@ -3493,7 +3547,7 @@ Object.assign(CodemanApp.prototype, {
       this._sendSyntheticSgrTap(touch.clientX, touch.clientY);
     }
 
-    if (intent === 'content') {
+    if (intent === 'content' && this._isActionableMobileTerminalTap(touch.clientX, touch.clientY)) {
       // A synthetic xterm click can focus its helper textarea. Blur after the
       // report so collapsing a readback never opens or retains the keyboard.
       this._blurMobileTerminalInput();

--- a/src/web/public/terminal-ui.js
+++ b/src/web/public/terminal-ui.js
@@ -53,6 +53,7 @@
   // Bound on page keys emitted from one gesture batch, mirroring the SGR tick
   // cap: a fling must not build a backlog that keeps paging after it stops.
   const PAGE_KEY_MAX_PER_BATCH = 3;
+  const TUI_PROMPT_DEFAULT_ROWS_FROM_BOTTOM = 4;
   // Composer navigation keys as xterm.js encodes user keystrokes: plain and
   // modified arrows (CSI A-D, CSI 1;mA-D, SS3 A-D), Home/End (CSI H/F, SS3
   // H/F, CSI 1~/4~), Insert/Delete/PgUp/PgDn (CSI 2~/3~/5~/6~, optional
@@ -180,6 +181,7 @@
     KEY_PAGE_DOWN,
     PAGE_KEY_SCREEN_FRACTION,
     PAGE_KEY_MAX_PER_BATCH,
+    TUI_PROMPT_DEFAULT_ROWS_FROM_BOTTOM,
   };
   global.CODEMAN_XTERM_THEMES = CODEMAN_XTERM_THEMES;
   global.codemanCurrentXtermTheme = currentXtermTheme;
@@ -3429,10 +3431,20 @@ Object.assign(CodemanApp.prototype, {
     if (promptRow >= 0) {
       const inputEnd = cursorRow >= promptRow ? cursorRow : promptRow;
       if (tappedRow >= promptRow && tappedRow <= inputEnd) return 'input';
-    } else if (tappedRow === cursorRow && cursorRow >= rows - 3) {
-      // During redraws a CLI can temporarily omit its prompt marker. Keep the
-      // live cursor row usable without turning arbitrary transcript rows into
-      // keyboard targets.
+    } else if (
+      tappedRow === cursorRow ||
+      tappedRow >=
+        Math.max(
+          0,
+          rows -
+            window.CodemanTerminalInput
+              .TUI_PROMPT_DEFAULT_ROWS_FROM_BOTTOM
+        )
+    ) {
+      // During redraws a CLI can temporarily omit its prompt marker or place
+      // the cursor above a status footer. Keep the live cursor and a stable
+      // lower-screen focus band usable without turning transcript rows above
+      // that band into keyboard targets.
       return 'input';
     }
 

--- a/src/web/public/terminal-ui.js
+++ b/src/web/public/terminal-ui.js
@@ -650,6 +650,7 @@ Object.assign(CodemanApp.prototype, {
 
       let didScroll = false; // track whether touchmove fired (tap vs scroll)
       let touchStartY = 0;
+      let tapCanActivateTerminal = false;
       const TAP_THRESHOLD = 8; // px — ignore micro-drift to distinguish tap from scroll
       container.addEventListener(
         'touchstart',
@@ -662,6 +663,7 @@ Object.assign(CodemanApp.prototype, {
             pixelAccum = 0;
             isTouching = true;
             didScroll = false;
+            tapCanActivateTerminal = this._shouldForwardMobileTapToApp();
             lastTime = 0;
             if (scrollFrame) {
               cancelAnimationFrame(scrollFrame);
@@ -737,9 +739,13 @@ Object.assign(CodemanApp.prototype, {
             if (touch) {
               this._suppressTrustedTapMouseEvents();
             }
-            if (touch && mouseTrackingOn) {
+            if (touch && tapCanActivateTerminal && mouseTrackingOn) {
               this._dispatchSyntheticTerminalClick(touch.clientX, touch.clientY);
-            } else if (touch && this._sessionUsesServerMouseStrip()) {
+            } else if (
+              touch &&
+              tapCanActivateTerminal &&
+              this._sessionUsesServerMouseStrip()
+            ) {
               // The server strips mouse-tracking DECSETs from claude/codex/gemini
               // output (isAltScreenStripMode, session.ts) so the wheel keeps
               // scrolling scrollback — which leaves THIS xterm permanently at
@@ -759,6 +765,7 @@ Object.assign(CodemanApp.prototype, {
               this.terminal.focus();
             }
           }
+          tapCanActivateTerminal = false;
         },
         { passive: true }
       );
@@ -3361,6 +3368,26 @@ Object.assign(CodemanApp.prototype, {
       xtermEl.style.setProperty('--xterm-helper-left', `${left}px`);
       xtermEl.style.setProperty('--xterm-helper-top', `${top}px`);
     } catch {}
+  },
+
+  /**
+   * A tap that opens the phone keyboard is focus-only. Forwarding that same
+   * gesture as a mouse click would activate the highlighted CLI menu option.
+   * Once the keyboard and terminal input were already active at touchstart,
+   * later taps may intentionally position the cursor or select a TUI row.
+   */
+  _shouldForwardMobileTapToApp() {
+    const keyboardVisible =
+      (typeof KeyboardHandler !== 'undefined' && KeyboardHandler.keyboardVisible) ||
+      document.body?.classList?.contains('keyboard-visible');
+    if (!keyboardVisible) return false;
+
+    const active = document.activeElement;
+    return (
+      active === this.terminal?.textarea ||
+      active?.classList?.contains('xterm-helper-textarea') ||
+      active?.id === 'cjkInput'
+    );
   },
 
   // ═══════════════════════════════════════════════════════════════

--- a/test/mobile/keyboard.test.ts
+++ b/test/mobile/keyboard.test.ts
@@ -756,12 +756,16 @@ describe('Virtual Keyboard', () => {
 
     it('focuses the terminal helper textarea when the terminal is tapped', async () => {
       await page.evaluate(() => {
+        window.__sentInputs = [];
         app.activeSessionId = 'mobile-focus-visible-input-test';
         app.sessions.set('mobile-focus-visible-input-test', {
           id: 'mobile-focus-visible-input-test',
           mode: 'codex',
           status: 'running',
         });
+        app._sendInputAsync = (_sessionId: string, input: string) => {
+          window.__sentInputs.push(input);
+        };
         app.hideWelcome();
         const settings = app.loadAppSettingsFromStorage();
         settings.cjkInputEnabled = false;
@@ -771,8 +775,12 @@ describe('Virtual Keyboard', () => {
 
       await page.locator('#terminalContainer').tap({ position: { x: 40, y: 40 } });
 
-      const activeClass = await page.evaluate(() => document.activeElement?.className);
-      expect(activeClass).toContain('xterm-helper-textarea');
+      const state = await page.evaluate(() => ({
+        activeClass: document.activeElement?.className,
+        sentInputs: window.__sentInputs,
+      }));
+      expect(state.activeClass).toContain('xterm-helper-textarea');
+      expect(state.sentInputs).toEqual([]);
     });
 
     // Regression guard for the phone-keyboard blocker reduced in #173 and re-hit

--- a/test/mobile/keyboard.test.ts
+++ b/test/mobile/keyboard.test.ts
@@ -756,6 +756,94 @@ describe('Virtual Keyboard', () => {
 
     it('focuses the terminal helper textarea when the terminal is tapped', async () => {
       await page.evaluate(() => {
+        app.activeSessionId = 'mobile-focus-visible-input-test';
+        app.sessions.set('mobile-focus-visible-input-test', {
+          id: 'mobile-focus-visible-input-test',
+          mode: 'codex',
+          status: 'running',
+        });
+        app.hideWelcome();
+        const settings = app.loadAppSettingsFromStorage();
+        settings.cjkInputEnabled = false;
+        app.saveAppSettingsToStorage(settings);
+        app._updateCjkInputState();
+      });
+
+      await page.locator('#terminalContainer').tap({ position: { x: 40, y: 40 } });
+
+      const activeClass = await page.evaluate(() => document.activeElement?.className);
+      expect(activeClass).toContain('xterm-helper-textarea');
+    });
+
+    // Regression guard for the phone-keyboard blocker reduced in #173 and re-hit
+    // by #244. selectSession() ends with scrollToLastNonEmptyLine(), which parks
+    // the viewport ABOVE the bottom for any session whose buffer is taller than
+    // the screen and ends in blank rows, i.e. every real session after a tab
+    // switch. A tap-routing scheme that treats "viewport is scrolled up" as a
+    // reason to blur strands document.activeElement on <body> with no way to
+    // raise the keyboard, and the prompt row is no exception. Suppressing the
+    // MOUSE REPORT while scrolled up is correct and pinned below; suppressing
+    // FOCUS is not. Measured against PR #244 on 2026-08-09: body vs textarea.
+    //
+    // Must be a dispatched gesture: calling the touchend handler directly
+    // bypasses touchstart's preventDefault, which is half of what closes the
+    // focus path, so a direct call reports the right intent and still misses.
+    it('keeps the terminal input focusable after a tab switch parks the viewport off-bottom', async () => {
+      const probe = await page.evaluate(async () => {
+        window.__sentInputs = [];
+        app.activeSessionId = 'mobile-offbottom-tap-test';
+        app.sessions.set('mobile-offbottom-tap-test', {
+          id: 'mobile-offbottom-tap-test',
+          mode: 'claude',
+          cliVersion: '2.1.220',
+          status: 'running',
+        });
+        app._sendInputAsync = (_sessionId: string, input: string) => {
+          window.__sentInputs.push(input);
+        };
+        app.hideWelcome();
+        const settings = app.loadAppSettingsFromStorage();
+        settings.cjkInputEnabled = false;
+        app.saveAppSettingsToStorage(settings);
+        app._updateCjkInputState();
+        app.terminal.reset();
+
+        // Taller than the viewport, ending in the trailing blank rows that make
+        // scrollToLastNonEmptyLine() stop short of the bottom.
+        const lines: string[] = [];
+        for (let i = 1; i <= app.terminal.rows * 3; i++) lines.push(`Transcript row ${i}`);
+        lines.push('', '❯ ', '', '');
+        await new Promise<void>((resolve) => app.terminal.write(lines.join('\r\n'), resolve));
+
+        app.scrollToLastNonEmptyLine(); // what selectSession() does on every tab switch
+        (document.activeElement as HTMLElement | null)?.blur?.();
+
+        const screen = app.terminal.element?.querySelector('.xterm-screen');
+        const cell = app.terminal._core?._renderService?.dimensions?.css?.cell;
+        const rect = screen?.getBoundingClientRect();
+        if (!rect || !cell?.width || !cell?.height) return null;
+        const buffer = app.terminal.buffer.active;
+        return {
+          x: rect.left + cell.width * 2,
+          y: rect.top + cell.height * 5.5,
+          atBottom: buffer.viewportY >= buffer.baseY,
+        };
+      });
+
+      expect(probe).not.toBeNull();
+      // The guard only means anything if the viewport really did park off-bottom.
+      expect(probe!.atBottom).toBe(false);
+
+      await page.touchscreen.tap(probe!.x, probe!.y);
+
+      const state = await page.evaluate(() => ({
+        activeClass: document.activeElement?.className,
+        sentInputs: window.__sentInputs,
+      }));
+      expect(state.activeClass).toContain('xterm-helper-textarea');
+      // SGR coordinates are meaningless off-bottom, so the tap must stay silent.
+      expect(state.sentInputs).toEqual([]);
+    });
 
     it('collapses a terminal readback without focusing the hidden textarea', async () => {
       const point = await page.evaluate(async () => {
@@ -961,42 +1049,6 @@ describe('Virtual Keyboard', () => {
           mode: 'codex',
           status: 'running',
         });
-        app.hideWelcome();
-        const settings = app.loadAppSettingsFromStorage();
-        settings.cjkInputEnabled = false;
-        app.saveAppSettingsToStorage(settings);
-        app._updateCjkInputState();
-      });
-
-      await page.locator('#terminalContainer').tap({ position: { x: 40, y: 40 } });
-
-      const activeClass = await page.evaluate(() => document.activeElement?.className);
-      expect(activeClass).toContain('xterm-helper-textarea');
-    });
-
-    // Regression guard for the phone-keyboard blocker reduced in #173 and re-hit
-    // by #244. selectSession() ends with scrollToLastNonEmptyLine(), which parks
-    // the viewport ABOVE the bottom for any session whose buffer is taller than
-    // the screen and ends in blank rows, i.e. every real session after a tab
-    // switch. A tap-routing scheme that treats "viewport is scrolled up" as a
-    // reason to blur strands document.activeElement on <body> with no way to
-    // raise the keyboard, and the prompt row is no exception. Suppressing the
-    // MOUSE REPORT while scrolled up is correct and pinned below; suppressing
-    // FOCUS is not. Measured against PR #244 on 2026-08-09: body vs textarea.
-    //
-    // Must be a dispatched gesture: calling the touchend handler directly
-    // bypasses touchstart's preventDefault, which is half of what closes the
-    // focus path, so a direct call reports the right intent and still misses.
-    it('keeps the terminal input focusable after a tab switch parks the viewport off-bottom', async () => {
-      const probe = await page.evaluate(async () => {
-        window.__sentInputs = [];
-        app.activeSessionId = 'mobile-offbottom-tap-test';
-        app.sessions.set('mobile-offbottom-tap-test', {
-          id: 'mobile-offbottom-tap-test',
-          mode: 'claude',
-          cliVersion: '2.1.220',
-          status: 'running',
-        });
         app._sendInputAsync = (_sessionId: string, input: string) => {
           window.__sentInputs.push(input);
         };
@@ -1006,41 +1058,29 @@ describe('Virtual Keyboard', () => {
         app.saveAppSettingsToStorage(settings);
         app._updateCjkInputState();
         app.terminal.reset();
-
-        // Taller than the viewport, ending in the trailing blank rows that make
-        // scrollToLastNonEmptyLine() stop short of the bottom.
-        const lines: string[] = [];
-        for (let i = 1; i <= app.terminal.rows * 3; i++) lines.push(`Transcript row ${i}`);
-        lines.push('', '❯ ', '', '');
-        await new Promise<void>((resolve) => app.terminal.write(lines.join('\r\n'), resolve));
-
-        app.scrollToLastNonEmptyLine(); // what selectSession() does on every tab switch
+        await new Promise<void>((resolve) =>
+          app.terminal.write('Agent readback\r\n  tap to collapse\r\n\r\n› ask', resolve)
+        );
         (document.activeElement as HTMLElement | null)?.blur?.();
 
         const screen = app.terminal.element?.querySelector('.xterm-screen');
         const cell = app.terminal._core?._renderService?.dimensions?.css?.cell;
         const rect = screen?.getBoundingClientRect();
         if (!rect || !cell?.width || !cell?.height) return null;
-        const buffer = app.terminal.buffer.active;
         return {
           x: rect.left + cell.width * 2,
-          y: rect.top + cell.height * 5.5,
-          atBottom: buffer.viewportY >= buffer.baseY,
+          y: rect.top + cell.height * (app.terminal.buffer.active.cursorY + 0.5),
         };
       });
+      expect(point).not.toBeNull();
 
-      expect(probe).not.toBeNull();
-      // The guard only means anything if the viewport really did park off-bottom.
-      expect(probe!.atBottom).toBe(false);
-
-      await page.touchscreen.tap(probe!.x, probe!.y);
+      await page.touchscreen.tap(point!.x, point!.y);
 
       const state = await page.evaluate(() => ({
         activeClass: document.activeElement?.className,
         sentInputs: window.__sentInputs,
       }));
       expect(state.activeClass).toContain('xterm-helper-textarea');
-      // SGR coordinates are meaningless off-bottom, so the tap must stay silent.
       expect(state.sentInputs).toEqual([]);
     });
 

--- a/test/mobile/keyboard.test.ts
+++ b/test/mobile/keyboard.test.ts
@@ -754,188 +754,25 @@ describe('Virtual Keyboard', () => {
       expect(state?.bodyClass).toBe(false);
     });
 
-    it('collapses a terminal readback without focusing the hidden textarea', async () => {
-      const point = await page.evaluate(async () => {
-        window.__sentInputs = [];
-        app.activeSessionId = 'mobile-readback-tap-test';
-        app.sessions.set('mobile-readback-tap-test', {
-          id: 'mobile-readback-tap-test',
-          mode: 'codex',
-          status: 'running',
-        });
-        app._sendInputAsync = (_sessionId: string, input: string) => {
-          window.__sentInputs.push(input);
-        };
-        app.hideWelcome();
-        const settings = app.loadAppSettingsFromStorage();
-        settings.cjkInputEnabled = false;
-        app.saveAppSettingsToStorage(settings);
-        app._updateCjkInputState();
-        app.terminal.reset();
-        await new Promise<void>((resolve) =>
-          app.terminal.write('Agent readback\r\n  tap to collapse\r\n\r\n› ask', resolve)
-        );
-        app.terminal.focus();
-
-        const screen = app.terminal.element?.querySelector('.xterm-screen');
-        const cell = app.terminal._core?._renderService?.dimensions?.css?.cell;
-        const rect = screen?.getBoundingClientRect();
-        if (!rect || !cell?.width || !cell?.height) return null;
-        return {
-          x: rect.left + cell.width * 2,
-          y: rect.top + cell.height / 2,
-        };
-      });
-      expect(point).not.toBeNull();
-
-      await page.touchscreen.tap(point!.x, point!.y);
-
-      const state = await page.evaluate(() => ({
-        activeClass: document.activeElement?.className,
-        sentInputs: window.__sentInputs,
-      }));
-      expect(state.activeClass).not.toContain('xterm-helper-textarea');
-      expect(state.sentInputs).toHaveLength(1);
-      expect(state.sentInputs[0]).toMatch(/^\x1b\[<0;\d+;1M\x1b\[<0;\d+;1m$/);
-    });
-
-    it('prevents Claude subagent status taps from opening the hidden keyboard input', async () => {
-      const point = await page.evaluate(async () => {
-        window.__sentInputs = [];
-        app.activeSessionId = 'mobile-claude-subagent-tap-test';
-        app.sessions.set('mobile-claude-subagent-tap-test', {
-          id: 'mobile-claude-subagent-tap-test',
-          mode: 'claude',
-          cliVersion: '2.1.220',
-          status: 'working',
-        });
-        app._sendInputAsync = (_sessionId: string, input: string) => {
-          window.__sentInputs.push(input);
-        };
-        app.hideWelcome();
-        app.terminal.reset();
-        const statusRow = Math.max(0, app.terminal.rows - 2);
-        await new Promise<void>((resolve) =>
-          app.terminal.write(
-            `${'\r\n'.repeat(statusRow)}• Working (1m 50s • esc to interrupt) · 1 background teammate`,
-            resolve
-          )
-        );
-        app.terminal.focus();
-
-        const screen = app.terminal.element?.querySelector('.xterm-screen');
-        const cell = app.terminal._core?._renderService?.dimensions?.css?.cell;
-        const rect = screen?.getBoundingClientRect();
-        if (!screen || !rect || !cell?.width || !cell?.height) return null;
-        const cursorRow = app.terminal.buffer.active.cursorY;
-        const x = rect.left + cell.width * 2;
-        const y = rect.top + cell.height * (cursorRow + 0.5);
-        return {
-          x,
-          y,
-          intent: app._classifyMobileTerminalTap(x, y),
-          cursorRow,
-          screenBottom: rect.bottom,
-        };
-      });
-      expect(point).toEqual(
-        expect.objectContaining({
-          intent: 'content',
-        })
-      );
-
-      const dispatch = await page.evaluate(({ x, y }) => {
-        const target = document.querySelector('#terminalContainer .xterm-screen');
-        if (!(target instanceof Element)) {
-          return { prevented: false, insideTerminal: false, targetClass: null };
-        }
-        const touch = new Touch({
-          identifier: 3,
-          target,
-          clientX: x,
-          clientY: y,
-          pageX: x,
-          pageY: y,
-        });
-        const allowed = target.dispatchEvent(
-          new TouchEvent('touchstart', {
-            touches: [touch],
-            changedTouches: [touch],
-            bubbles: true,
-            cancelable: true,
-          })
-        );
-        target.dispatchEvent(
-          new TouchEvent('touchend', {
-            touches: [],
-            changedTouches: [touch],
-            bubbles: true,
-            cancelable: true,
-          })
-        );
-        return {
-          prevented: !allowed,
-          insideTerminal: Boolean(target.closest('#terminalContainer')),
-          targetClass: target.className,
-        };
-      }, point!);
-
-      const state = await page.evaluate(() => ({
-        activeClass: document.activeElement?.className,
-        sentInputs: window.__sentInputs,
-      }));
-      expect(dispatch).toEqual(
-        expect.objectContaining({
-          prevented: true,
-          insideTerminal: true,
-        })
-      );
-      expect(state.activeClass).not.toContain('xterm-helper-textarea');
-      expect(state.sentInputs).toHaveLength(1);
-    });
-
-    it('focuses the terminal helper textarea when the visible prompt is tapped', async () => {
-      const point = await page.evaluate(async () => {
-        window.__sentInputs = [];
+    it('focuses the terminal helper textarea when the terminal is tapped', async () => {
+      await page.evaluate(() => {
         app.activeSessionId = 'mobile-focus-visible-input-test';
         app.sessions.set('mobile-focus-visible-input-test', {
           id: 'mobile-focus-visible-input-test',
           mode: 'codex',
           status: 'running',
         });
-        app._sendInputAsync = (_sessionId: string, input: string) => {
-          window.__sentInputs.push(input);
-        };
         app.hideWelcome();
         const settings = app.loadAppSettingsFromStorage();
         settings.cjkInputEnabled = false;
         app.saveAppSettingsToStorage(settings);
         app._updateCjkInputState();
-        app.terminal.reset();
-        await new Promise<void>((resolve) =>
-          app.terminal.write('Agent readback\r\n  tap to collapse\r\n\r\n› ask', resolve)
-        );
-        (document.activeElement as HTMLElement | null)?.blur?.();
-
-        const screen = app.terminal.element?.querySelector('.xterm-screen');
-        const cell = app.terminal._core?._renderService?.dimensions?.css?.cell;
-        const rect = screen?.getBoundingClientRect();
-        if (!rect || !cell?.width || !cell?.height) return null;
-        return {
-          x: rect.left + cell.width * 2,
-          y: rect.top + cell.height * (app.terminal.buffer.active.cursorY + 0.5),
-        };
       });
-      expect(point).not.toBeNull();
 
-      await page.touchscreen.tap(point!.x, point!.y);
+      await page.locator('#terminalContainer').tap({ position: { x: 40, y: 40 } });
 
-      const state = await page.evaluate(() => ({
-        activeClass: document.activeElement?.className,
-        sentInputs: window.__sentInputs,
-      }));
-      expect(state.activeClass).toContain('xterm-helper-textarea');
-      expect(state.sentInputs).toEqual([]);
+      const activeClass = await page.evaluate(() => document.activeElement?.className);
+      expect(activeClass).toContain('xterm-helper-textarea');
     });
 
     // Regression guard for the phone-keyboard blocker reduced in #173 and re-hit
@@ -1008,6 +845,44 @@ describe('Virtual Keyboard', () => {
       expect(state.sentInputs).toEqual([]);
     });
 
+    it('focuses the live Claude cursor when a redraw omits the prompt glyph', async () => {
+      const point = await page.evaluate(async () => {
+        window.__sentInputs = [];
+        app.activeSessionId = 'mobile-focus-promptless-claude-test';
+        app.sessions.set('mobile-focus-promptless-claude-test', {
+          id: 'mobile-focus-promptless-claude-test',
+          mode: 'claude',
+          status: 'running',
+        });
+        app._sendInputAsync = (_sessionId: string, input: string) => {
+          window.__sentInputs.push(input);
+        };
+        app.hideWelcome();
+        app.terminal.reset();
+        await new Promise<void>((resolve) => app.terminal.write('Claude response\r\nready for input', resolve));
+        (document.activeElement as HTMLElement | null)?.blur?.();
+
+        const screen = app.terminal.element?.querySelector('.xterm-screen');
+        const cell = app.terminal._core?._renderService?.dimensions?.css?.cell;
+        const rect = screen?.getBoundingClientRect();
+        if (!rect || !cell?.width || !cell?.height) return null;
+        return {
+          x: rect.left + cell.width * 2,
+          y: rect.top + cell.height * (app.terminal.buffer.active.cursorY + 0.5),
+        };
+      });
+      expect(point).not.toBeNull();
+
+      await page.touchscreen.tap(point!.x, point!.y);
+
+      const state = await page.evaluate(() => ({
+        activeClass: document.activeElement?.className,
+        sentInputs: window.__sentInputs,
+      }));
+      expect(state.activeClass).toContain('xterm-helper-textarea');
+      expect(state.sentInputs).toEqual([]);
+    });
+
     it('keeps terminal touch drag available for scrollback with the visible textarea enabled', async () => {
       const calls = await page.evaluate(async () => {
         app.activeSessionId = 'mobile-touch-scroll-test';
@@ -1075,77 +950,6 @@ describe('Virtual Keyboard', () => {
 
       expect(calls.length).toBeGreaterThan(0);
       expect(calls.some((lines) => lines !== 0)).toBe(true);
-    });
-
-    it('routes Claude touch drags to its transcript without moving local xterm history', async () => {
-      const result = await page.evaluate(async () => {
-        app.activeSessionId = 'mobile-claude-scroll-test';
-        app.sessions.set('mobile-claude-scroll-test', {
-          id: 'mobile-claude-scroll-test',
-          mode: 'claude',
-          cliVersion: '2.1.220',
-          status: 'running',
-        });
-        app.hideWelcome();
-
-        const sgrCalls: number[] = [];
-        const localCalls: number[] = [];
-        app._sendSyntheticSgrWheel = (_x: number, _y: number, lines: number) => {
-          sgrCalls.push(lines);
-        };
-        app.terminal.scrollLines = (lines: number) => {
-          localCalls.push(lines);
-        };
-
-        const target =
-          document.querySelector('#terminalContainer .xterm-screen') ?? document.getElementById('terminalContainer');
-        if (!target) return { sgrCalls, localCalls };
-        const rect = target.getBoundingClientRect();
-        const x = rect.left + rect.width / 2;
-        const startY = rect.top + Math.min(100, rect.height - 20);
-        const endY = startY + 100;
-
-        function createTouch(y: number) {
-          return new Touch({
-            identifier: 2,
-            target,
-            clientX: x,
-            clientY: y,
-            pageX: x,
-            pageY: y,
-          });
-        }
-
-        target.dispatchEvent(
-          new TouchEvent('touchstart', {
-            touches: [createTouch(startY)],
-            changedTouches: [createTouch(startY)],
-            bubbles: true,
-            cancelable: true,
-          })
-        );
-        target.dispatchEvent(
-          new TouchEvent('touchmove', {
-            touches: [createTouch(endY)],
-            changedTouches: [createTouch(endY)],
-            bubbles: true,
-            cancelable: true,
-          })
-        );
-        target.dispatchEvent(
-          new TouchEvent('touchend', {
-            touches: [],
-            changedTouches: [createTouch(endY)],
-            bubbles: true,
-            cancelable: true,
-          })
-        );
-        await new Promise((resolve) => setTimeout(resolve, 50));
-        return { sgrCalls, localCalls };
-      });
-
-      expect(result.sgrCalls.some((lines) => lines < 0)).toBe(true);
-      expect(result.localCalls).toEqual([]);
     });
 
     it('keeps typed phone text in the terminal local echo path', async () => {

--- a/test/mobile/keyboard.test.ts
+++ b/test/mobile/keyboard.test.ts
@@ -756,6 +756,205 @@ describe('Virtual Keyboard', () => {
 
     it('focuses the terminal helper textarea when the terminal is tapped', async () => {
       await page.evaluate(() => {
+
+    it('collapses a terminal readback without focusing the hidden textarea', async () => {
+      const point = await page.evaluate(async () => {
+        window.__sentInputs = [];
+        app.activeSessionId = 'mobile-readback-tap-test';
+        app.sessions.set('mobile-readback-tap-test', {
+          id: 'mobile-readback-tap-test',
+          mode: 'codex',
+          status: 'running',
+        });
+        app._sendInputAsync = (_sessionId: string, input: string) => {
+          window.__sentInputs.push(input);
+        };
+        app.hideWelcome();
+        const settings = app.loadAppSettingsFromStorage();
+        settings.cjkInputEnabled = false;
+        app.saveAppSettingsToStorage(settings);
+        app._updateCjkInputState();
+        app.terminal.reset();
+        await new Promise<void>((resolve) =>
+          app.terminal.write('Agent readback\r\n  tap to collapse\r\n\r\n› ask', resolve)
+        );
+        app.terminal.focus();
+
+        const screen = app.terminal.element?.querySelector('.xterm-screen');
+        const cell = app.terminal._core?._renderService?.dimensions?.css?.cell;
+        const rect = screen?.getBoundingClientRect();
+        if (!rect || !cell?.width || !cell?.height) return null;
+        return {
+          x: rect.left + cell.width * 2,
+          y: rect.top + cell.height / 2,
+        };
+      });
+      expect(point).not.toBeNull();
+
+      await page.touchscreen.tap(point!.x, point!.y);
+
+      const state = await page.evaluate(() => ({
+        activeClass: document.activeElement?.className,
+        sentInputs: window.__sentInputs,
+      }));
+      expect(state.activeClass).not.toContain('xterm-helper-textarea');
+      expect(state.sentInputs).toHaveLength(1);
+      expect(state.sentInputs[0]).toMatch(/^\x1b\[<0;\d+;1M\x1b\[<0;\d+;1m$/);
+    });
+
+    it('keeps the hidden keyboard input focused after an inert Claude transcript tap', async () => {
+      const point = await page.evaluate(async () => {
+        window.__sentInputs = [];
+        app.activeSessionId = 'mobile-claude-transcript-tap-test';
+        app.sessions.set('mobile-claude-transcript-tap-test', {
+          id: 'mobile-claude-transcript-tap-test',
+          mode: 'claude',
+          cliVersion: '2.1.220',
+          status: 'working',
+        });
+        app._sendInputAsync = (_sessionId: string, input: string) => {
+          window.__sentInputs.push(input);
+        };
+        app.hideWelcome();
+        const settings = app.loadAppSettingsFromStorage();
+        settings.cjkInputEnabled = false;
+        app.saveAppSettingsToStorage(settings);
+        app._updateCjkInputState();
+        app.terminal.reset();
+        await new Promise<void>((resolve) =>
+          app.terminal.write(
+            'Transcript row one\r\nTranscript row two\r\nTranscript row three\r\nTranscript row four\r\nTranscript row five\r\nTranscript row six\r\nTranscript row seven\r\nTranscript row eight\r\nTranscript row nine\r\nTranscript row ten\r\n\r\n❯ ',
+            resolve
+          )
+        );
+        app.terminal.focus();
+
+        const screen = app.terminal.element?.querySelector('.xterm-screen');
+        const cell = app.terminal._core?._renderService?.dimensions?.css?.cell;
+        const rect = screen?.getBoundingClientRect();
+        if (!screen || !rect || !cell?.width || !cell?.height) return null;
+        const cursorRow = app.terminal.buffer.active.cursorY;
+        const transcriptRow = Math.max(1, Math.floor(cursorRow / 2));
+        const x = rect.left + cell.width * 2;
+        const y = rect.top + cell.height * (transcriptRow + 0.5);
+        return {
+          x,
+          y,
+          intent: app._classifyMobileTerminalTap(x, y),
+          activeClass: document.activeElement?.className,
+        };
+      });
+      expect(point).toEqual(
+        expect.objectContaining({
+          intent: 'content',
+          activeClass: expect.stringContaining('xterm-helper-textarea'),
+        })
+      );
+
+      await page.touchscreen.tap(point!.x, point!.y);
+
+      const activeClass = await page.evaluate(() => document.activeElement?.className);
+      expect(activeClass).toContain('xterm-helper-textarea');
+    });
+
+    it('prevents Claude subagent status taps from opening the hidden keyboard input', async () => {
+      const point = await page.evaluate(async () => {
+        window.__sentInputs = [];
+        app.activeSessionId = 'mobile-claude-subagent-tap-test';
+        app.sessions.set('mobile-claude-subagent-tap-test', {
+          id: 'mobile-claude-subagent-tap-test',
+          mode: 'claude',
+          cliVersion: '2.1.220',
+          status: 'working',
+        });
+        app._sendInputAsync = (_sessionId: string, input: string) => {
+          window.__sentInputs.push(input);
+        };
+        app.hideWelcome();
+        app.terminal.reset();
+        const statusRow = Math.max(0, app.terminal.rows - 2);
+        await new Promise<void>((resolve) =>
+          app.terminal.write(
+            `${'\r\n'.repeat(statusRow)}• Working (1m 50s • esc to interrupt) · 1 background teammate`,
+            resolve
+          )
+        );
+        app.terminal.focus();
+
+        const screen = app.terminal.element?.querySelector('.xterm-screen');
+        const cell = app.terminal._core?._renderService?.dimensions?.css?.cell;
+        const rect = screen?.getBoundingClientRect();
+        if (!screen || !rect || !cell?.width || !cell?.height) return null;
+        const cursorRow = app.terminal.buffer.active.cursorY;
+        const x = rect.left + cell.width * 2;
+        const y = rect.top + cell.height * (cursorRow + 0.5);
+        return {
+          x,
+          y,
+          intent: app._classifyMobileTerminalTap(x, y),
+          cursorRow,
+          screenBottom: rect.bottom,
+        };
+      });
+      expect(point).toEqual(
+        expect.objectContaining({
+          intent: 'content',
+        })
+      );
+
+      const dispatch = await page.evaluate(({ x, y }) => {
+        const target = document.querySelector('#terminalContainer .xterm-screen');
+        if (!(target instanceof Element)) {
+          return { prevented: false, insideTerminal: false, targetClass: null };
+        }
+        const touch = new Touch({
+          identifier: 3,
+          target,
+          clientX: x,
+          clientY: y,
+          pageX: x,
+          pageY: y,
+        });
+        const allowed = target.dispatchEvent(
+          new TouchEvent('touchstart', {
+            touches: [touch],
+            changedTouches: [touch],
+            bubbles: true,
+            cancelable: true,
+          })
+        );
+        target.dispatchEvent(
+          new TouchEvent('touchend', {
+            touches: [],
+            changedTouches: [touch],
+            bubbles: true,
+            cancelable: true,
+          })
+        );
+        return {
+          prevented: !allowed,
+          insideTerminal: Boolean(target.closest('#terminalContainer')),
+          targetClass: target.className,
+        };
+      }, point!);
+
+      const state = await page.evaluate(() => ({
+        activeClass: document.activeElement?.className,
+        sentInputs: window.__sentInputs,
+      }));
+      expect(dispatch).toEqual(
+        expect.objectContaining({
+          prevented: true,
+          insideTerminal: true,
+        })
+      );
+      expect(state.activeClass).not.toContain('xterm-helper-textarea');
+      expect(state.sentInputs).toHaveLength(1);
+    });
+
+    it('focuses the terminal helper textarea when the visible prompt is tapped', async () => {
+      const point = await page.evaluate(async () => {
+        window.__sentInputs = [];
         app.activeSessionId = 'mobile-focus-visible-input-test';
         app.sessions.set('mobile-focus-visible-input-test', {
           id: 'mobile-focus-visible-input-test',

--- a/test/mobile/keyboard.test.ts
+++ b/test/mobile/keyboard.test.ts
@@ -799,6 +799,101 @@ describe('Virtual Keyboard', () => {
       expect(state.sentInputs[0]).toMatch(/^\x1b\[<0;\d+;1M\x1b\[<0;\d+;1m$/);
     });
 
+    it('prevents Claude subagent status taps from opening the hidden keyboard input', async () => {
+      const point = await page.evaluate(async () => {
+        window.__sentInputs = [];
+        app.activeSessionId = 'mobile-claude-subagent-tap-test';
+        app.sessions.set('mobile-claude-subagent-tap-test', {
+          id: 'mobile-claude-subagent-tap-test',
+          mode: 'claude',
+          cliVersion: '2.1.220',
+          status: 'working',
+        });
+        app._sendInputAsync = (_sessionId: string, input: string) => {
+          window.__sentInputs.push(input);
+        };
+        app.hideWelcome();
+        app.terminal.reset();
+        const statusRow = Math.max(0, app.terminal.rows - 2);
+        await new Promise<void>((resolve) =>
+          app.terminal.write(
+            `${'\r\n'.repeat(statusRow)}• Working (1m 50s • esc to interrupt) · 1 background teammate`,
+            resolve
+          )
+        );
+        app.terminal.focus();
+
+        const screen = app.terminal.element?.querySelector('.xterm-screen');
+        const cell = app.terminal._core?._renderService?.dimensions?.css?.cell;
+        const rect = screen?.getBoundingClientRect();
+        if (!screen || !rect || !cell?.width || !cell?.height) return null;
+        const cursorRow = app.terminal.buffer.active.cursorY;
+        const x = rect.left + cell.width * 2;
+        const y = rect.top + cell.height * (cursorRow + 0.5);
+        return {
+          x,
+          y,
+          intent: app._classifyMobileTerminalTap(x, y),
+          cursorRow,
+          screenBottom: rect.bottom,
+        };
+      });
+      expect(point).toEqual(
+        expect.objectContaining({
+          intent: 'content',
+        })
+      );
+
+      const dispatch = await page.evaluate(({ x, y }) => {
+        const target = document.querySelector('#terminalContainer .xterm-screen');
+        if (!(target instanceof Element)) {
+          return { prevented: false, insideTerminal: false, targetClass: null };
+        }
+        const touch = new Touch({
+          identifier: 3,
+          target,
+          clientX: x,
+          clientY: y,
+          pageX: x,
+          pageY: y,
+        });
+        const allowed = target.dispatchEvent(
+          new TouchEvent('touchstart', {
+            touches: [touch],
+            changedTouches: [touch],
+            bubbles: true,
+            cancelable: true,
+          })
+        );
+        target.dispatchEvent(
+          new TouchEvent('touchend', {
+            touches: [],
+            changedTouches: [touch],
+            bubbles: true,
+            cancelable: true,
+          })
+        );
+        return {
+          prevented: !allowed,
+          insideTerminal: Boolean(target.closest('#terminalContainer')),
+          targetClass: target.className,
+        };
+      }, point!);
+
+      const state = await page.evaluate(() => ({
+        activeClass: document.activeElement?.className,
+        sentInputs: window.__sentInputs,
+      }));
+      expect(dispatch).toEqual(
+        expect.objectContaining({
+          prevented: true,
+          insideTerminal: true,
+        })
+      );
+      expect(state.activeClass).not.toContain('xterm-helper-textarea');
+      expect(state.sentInputs).toHaveLength(1);
+    });
+
     it('focuses the terminal helper textarea when the visible prompt is tapped', async () => {
       const point = await page.evaluate(async () => {
         window.__sentInputs = [];
@@ -980,6 +1075,77 @@ describe('Virtual Keyboard', () => {
 
       expect(calls.length).toBeGreaterThan(0);
       expect(calls.some((lines) => lines !== 0)).toBe(true);
+    });
+
+    it('routes Claude touch drags to its transcript without moving local xterm history', async () => {
+      const result = await page.evaluate(async () => {
+        app.activeSessionId = 'mobile-claude-scroll-test';
+        app.sessions.set('mobile-claude-scroll-test', {
+          id: 'mobile-claude-scroll-test',
+          mode: 'claude',
+          cliVersion: '2.1.220',
+          status: 'running',
+        });
+        app.hideWelcome();
+
+        const sgrCalls: number[] = [];
+        const localCalls: number[] = [];
+        app._sendSyntheticSgrWheel = (_x: number, _y: number, lines: number) => {
+          sgrCalls.push(lines);
+        };
+        app.terminal.scrollLines = (lines: number) => {
+          localCalls.push(lines);
+        };
+
+        const target =
+          document.querySelector('#terminalContainer .xterm-screen') ?? document.getElementById('terminalContainer');
+        if (!target) return { sgrCalls, localCalls };
+        const rect = target.getBoundingClientRect();
+        const x = rect.left + rect.width / 2;
+        const startY = rect.top + Math.min(100, rect.height - 20);
+        const endY = startY + 100;
+
+        function createTouch(y: number) {
+          return new Touch({
+            identifier: 2,
+            target,
+            clientX: x,
+            clientY: y,
+            pageX: x,
+            pageY: y,
+          });
+        }
+
+        target.dispatchEvent(
+          new TouchEvent('touchstart', {
+            touches: [createTouch(startY)],
+            changedTouches: [createTouch(startY)],
+            bubbles: true,
+            cancelable: true,
+          })
+        );
+        target.dispatchEvent(
+          new TouchEvent('touchmove', {
+            touches: [createTouch(endY)],
+            changedTouches: [createTouch(endY)],
+            bubbles: true,
+            cancelable: true,
+          })
+        );
+        target.dispatchEvent(
+          new TouchEvent('touchend', {
+            touches: [],
+            changedTouches: [createTouch(endY)],
+            bubbles: true,
+            cancelable: true,
+          })
+        );
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        return { sgrCalls, localCalls };
+      });
+
+      expect(result.sgrCalls.some((lines) => lines < 0)).toBe(true);
+      expect(result.localCalls).toEqual([]);
     });
 
     it('keeps typed phone text in the terminal local echo path', async () => {

--- a/test/mobile/keyboard.test.ts
+++ b/test/mobile/keyboard.test.ts
@@ -754,8 +754,53 @@ describe('Virtual Keyboard', () => {
       expect(state?.bodyClass).toBe(false);
     });
 
-    it('focuses the terminal helper textarea when the terminal is tapped', async () => {
-      await page.evaluate(() => {
+    it('collapses a terminal readback without focusing the hidden textarea', async () => {
+      const point = await page.evaluate(async () => {
+        window.__sentInputs = [];
+        app.activeSessionId = 'mobile-readback-tap-test';
+        app.sessions.set('mobile-readback-tap-test', {
+          id: 'mobile-readback-tap-test',
+          mode: 'codex',
+          status: 'running',
+        });
+        app._sendInputAsync = (_sessionId: string, input: string) => {
+          window.__sentInputs.push(input);
+        };
+        app.hideWelcome();
+        const settings = app.loadAppSettingsFromStorage();
+        settings.cjkInputEnabled = false;
+        app.saveAppSettingsToStorage(settings);
+        app._updateCjkInputState();
+        app.terminal.reset();
+        await new Promise<void>((resolve) =>
+          app.terminal.write('Agent readback\r\n  tap to collapse\r\n\r\n› ask', resolve)
+        );
+        app.terminal.focus();
+
+        const screen = app.terminal.element?.querySelector('.xterm-screen');
+        const cell = app.terminal._core?._renderService?.dimensions?.css?.cell;
+        const rect = screen?.getBoundingClientRect();
+        if (!rect || !cell?.width || !cell?.height) return null;
+        return {
+          x: rect.left + cell.width * 2,
+          y: rect.top + cell.height / 2,
+        };
+      });
+      expect(point).not.toBeNull();
+
+      await page.touchscreen.tap(point!.x, point!.y);
+
+      const state = await page.evaluate(() => ({
+        activeClass: document.activeElement?.className,
+        sentInputs: window.__sentInputs,
+      }));
+      expect(state.activeClass).not.toContain('xterm-helper-textarea');
+      expect(state.sentInputs).toHaveLength(1);
+      expect(state.sentInputs[0]).toMatch(/^\x1b\[<0;\d+;1M\x1b\[<0;\d+;1m$/);
+    });
+
+    it('focuses the terminal helper textarea when the visible prompt is tapped', async () => {
+      const point = await page.evaluate(async () => {
         window.__sentInputs = [];
         app.activeSessionId = 'mobile-focus-visible-input-test';
         app.sessions.set('mobile-focus-visible-input-test', {
@@ -771,9 +816,24 @@ describe('Virtual Keyboard', () => {
         settings.cjkInputEnabled = false;
         app.saveAppSettingsToStorage(settings);
         app._updateCjkInputState();
-      });
+        app.terminal.reset();
+        await new Promise<void>((resolve) =>
+          app.terminal.write('Agent readback\r\n  tap to collapse\r\n\r\n› ask', resolve)
+        );
+        (document.activeElement as HTMLElement | null)?.blur?.();
 
-      await page.locator('#terminalContainer').tap({ position: { x: 40, y: 40 } });
+        const screen = app.terminal.element?.querySelector('.xterm-screen');
+        const cell = app.terminal._core?._renderService?.dimensions?.css?.cell;
+        const rect = screen?.getBoundingClientRect();
+        if (!rect || !cell?.width || !cell?.height) return null;
+        return {
+          x: rect.left + cell.width * 2,
+          y: rect.top + cell.height * (app.terminal.buffer.active.cursorY + 0.5),
+        };
+      });
+      expect(point).not.toBeNull();
+
+      await page.touchscreen.tap(point!.x, point!.y);
 
       const state = await page.evaluate(() => ({
         activeClass: document.activeElement?.className,

--- a/test/terminal-touch-tap.test.ts
+++ b/test/terminal-touch-tap.test.ts
@@ -15,6 +15,7 @@ function loadTerminalUiHarness() {
       get activeElement() {
         return activeElement;
       },
+      getElementById: () => null,
     },
     CodemanApp,
     console: { warn: vi.fn(), log: vi.fn() },
@@ -74,18 +75,103 @@ function createElementHarness() {
   };
 }
 
+function createTerminalGrid(lines: string[], cursorY: number) {
+  const textarea = {
+    classList: { contains: (name: string) => name === 'xterm-helper-textarea' },
+    blur: vi.fn(),
+  };
+  return {
+    cols: 80,
+    rows: lines.length,
+    modes: { mouseTrackingMode: 'none' },
+    buffer: {
+      active: {
+        viewportY: 0,
+        baseY: 0,
+        cursorY,
+        getLine: (row: number) =>
+          row >= 0 && row < lines.length ? { translateToString: () => lines[row] } : undefined,
+      },
+    },
+    element: {
+      querySelector: (selector: string) =>
+        selector === '.xterm-screen' ? { getBoundingClientRect: () => ({ left: 0, top: 0 }) } : null,
+    },
+    _core: { _renderService: { dimensions: { css: { cell: { width: 8, height: 16 } } } } },
+    textarea,
+    focus: vi.fn(),
+  };
+}
+
 describe('terminal touch tap mouse guard', () => {
-  it('keeps the keyboard-opening tap focus-only', () => {
-    const { app, setActiveElement, setKeyboardVisible } = loadTerminalUiHarness();
+  it('recognizes focus only when a terminal input owns the active element', () => {
+    const { app, setActiveElement } = loadTerminalUiHarness();
     const textarea = { classList: { contains: () => true } };
     app.terminal = { textarea };
+
+    setActiveElement(null);
+    expect(app._isMobileTerminalInputFocused()).toBe(false);
+
     setActiveElement(textarea);
+    expect(app._isMobileTerminalInputFocused()).toBe(true);
+  });
 
-    setKeyboardVisible(false);
-    expect(app._shouldForwardMobileTapToApp()).toBe(false);
+  it('routes a readback row to the TUI while keeping the prompt row as keyboard input', () => {
+    const { app } = loadTerminalUiHarness();
+    app.activeSessionId = 'sess-1';
+    app.sessions = new Map([['sess-1', { mode: 'codex' }]]);
+    app.terminal = createTerminalGrid(
+      ['Agent readback mentions › inline', '  tap to collapse', '', '', '› ask', 'gpt-5 · Context 80% left'],
+      4
+    );
 
-    setKeyboardVisible(true);
-    expect(app._shouldForwardMobileTapToApp()).toBe(true);
+    expect(app._classifyMobileTerminalTap(9, 1)).toBe('content'); // inline marker is not a prompt
+    expect(app._classifyMobileTerminalTap(9, 17)).toBe('content'); // row 2: readback
+    expect(app._classifyMobileTerminalTap(9, 65)).toBe('input'); // row 5: prompt
+    expect(app._classifyMobileTerminalTap(9, 81)).toBe('content'); // row 6: status
+  });
+
+  it('treats a highlighted numbered choice as TUI content, not an input prompt', () => {
+    const { app } = loadTerminalUiHarness();
+    app.activeSessionId = 'sess-1';
+    app.sessions = new Map([['sess-1', { mode: 'claude' }]]);
+    app.terminal = createTerminalGrid(['Would you like to proceed?', '', '❯ 1. Yes', '  2. No', '', ''], 2);
+
+    expect(app._classifyMobileTerminalTap(9, 33)).toBe('content');
+    expect(app._classifyMobileTerminalTap(9, 49)).toBe('content');
+  });
+
+  it('collapses TUI readback content without opening or retaining the keyboard', () => {
+    const { app, setActiveElement } = loadTerminalUiHarness();
+    app.activeSessionId = 'sess-1';
+    app.sessions = new Map([['sess-1', { mode: 'codex' }]]);
+    app.terminal = createTerminalGrid(
+      ['Agent readback', '  tap to collapse', '', '', '› ask', 'gpt-5 · Context 80% left'],
+      4
+    );
+    app._sendInputAsync = vi.fn();
+    setActiveElement(app.terminal.textarea);
+
+    expect(app._handleMobileTerminalTap({ clientX: 9, clientY: 17 }, true)).toBe('content');
+    expect(app._sendInputAsync).toHaveBeenCalledWith('sess-1', '\x1b[<0;2;2M\x1b[<0;2;2m');
+    expect(app.terminal.textarea.blur).toHaveBeenCalledOnce();
+    expect(app.terminal.focus).not.toHaveBeenCalled();
+  });
+
+  it('keeps the first prompt tap focus-only so it cannot activate a CLI row', () => {
+    const { app, setActiveElement } = loadTerminalUiHarness();
+    app.activeSessionId = 'sess-1';
+    app.sessions = new Map([['sess-1', { mode: 'codex' }]]);
+    app.terminal = createTerminalGrid(
+      ['Agent readback', '  tap to collapse', '', '', '› ask', 'gpt-5 · Context 80% left'],
+      4
+    );
+    app._sendInputAsync = vi.fn();
+    setActiveElement(null);
+
+    expect(app._handleMobileTerminalTap({ clientX: 9, clientY: 65 }, false)).toBe('input');
+    expect(app._sendInputAsync).not.toHaveBeenCalled();
+    expect(app.terminal.focus).toHaveBeenCalledOnce();
   });
 
   it('suppresses browser trusted compatibility mouse events during the tap window', () => {

--- a/test/terminal-touch-tap.test.ts
+++ b/test/terminal-touch-tap.test.ts
@@ -6,8 +6,16 @@ import { describe, expect, it, vi } from 'vitest';
 function loadTerminalUiHarness() {
   const CodemanApp = function CodemanApp(this: any) {};
   let now = 1_000;
+  let keyboardVisible = false;
+  let activeElement: unknown = null;
   const context = vm.createContext({
     window: {},
+    document: {
+      body: { classList: { contains: () => false } },
+      get activeElement() {
+        return activeElement;
+      },
+    },
     CodemanApp,
     console: { warn: vi.fn(), log: vi.fn() },
     _crashDiag: { log: vi.fn() },
@@ -25,6 +33,11 @@ function loadTerminalUiHarness() {
     MobileDetection: {
       isTouchDevice: () => true,
     },
+    KeyboardHandler: {
+      get keyboardVisible() {
+        return keyboardVisible;
+      },
+    },
     DEC_SYNC_STRIP_RE: /\x1b\[\?2026[hl]/g,
     TERMINAL_CHUNK_SIZE: 32 * 1024,
   });
@@ -37,6 +50,12 @@ function loadTerminalUiHarness() {
     app,
     setNow: (value: number) => {
       now = value;
+    },
+    setKeyboardVisible: (visible: boolean) => {
+      keyboardVisible = visible;
+    },
+    setActiveElement: (element: unknown) => {
+      activeElement = element;
     },
   };
 }
@@ -56,6 +75,19 @@ function createElementHarness() {
 }
 
 describe('terminal touch tap mouse guard', () => {
+  it('keeps the keyboard-opening tap focus-only', () => {
+    const { app, setActiveElement, setKeyboardVisible } = loadTerminalUiHarness();
+    const textarea = { classList: { contains: () => true } };
+    app.terminal = { textarea };
+    setActiveElement(textarea);
+
+    setKeyboardVisible(false);
+    expect(app._shouldForwardMobileTapToApp()).toBe(false);
+
+    setKeyboardVisible(true);
+    expect(app._shouldForwardMobileTapToApp()).toBe(true);
+  });
+
   it('suppresses browser trusted compatibility mouse events during the tap window', () => {
     const { app } = loadTerminalUiHarness();
     const { element, dispatch } = createElementHarness();

--- a/test/terminal-touch-tap.test.ts
+++ b/test/terminal-touch-tap.test.ts
@@ -146,6 +146,16 @@ describe('terminal touch tap mouse guard', () => {
     expect(app._classifyMobileTerminalTap(9, 65)).toBe('content');
   });
 
+  it('keeps the live cursor focusable when Claude temporarily omits its prompt glyph', () => {
+    const { app } = loadTerminalUiHarness();
+    app.activeSessionId = 'sess-1';
+    app.sessions = new Map([['sess-1', { mode: 'claude' }]]);
+    app.terminal = createTerminalGrid(['Prior response', '', 'ready for input', '', 'status footer', ''], 2);
+
+    expect(app._classifyMobileTerminalTap(9, 33)).toBe('input');
+    expect(app._classifyMobileTerminalTap(9, 1)).toBe('content');
+  });
+
   it('treats a highlighted numbered choice as TUI content, not an input prompt', () => {
     const { app } = loadTerminalUiHarness();
     app.activeSessionId = 'sess-1';

--- a/test/terminal-touch-tap.test.ts
+++ b/test/terminal-touch-tap.test.ts
@@ -543,25 +543,6 @@ describe('terminal touch tap mouse guard', () => {
     expect(app._shouldForwardWheelToApp({ shiftKey: false })).toBe(false);
   });
 
-  it('touch: forwards verified Claude transcript scrolling but keeps Codex touch in local history', () => {
-    const { app } = loadTerminalUiHarness();
-    app.activeSessionId = 'sess-1';
-    app.terminal = {
-      modes: { mouseTrackingMode: 'none' },
-      buffer: { active: { viewportY: 50, baseY: 50 } },
-    };
-
-    app.sessions = new Map([['sess-1', { mode: 'claude', cliVersion: '2.1.220' }]]);
-    expect(app._shouldForwardTouchScrollToApp()).toBe(true);
-
-    app.loadAppSettingsFromStorage = () => ({ terminalWheelLocalScrollback: true });
-    expect(app._shouldForwardTouchScrollToApp()).toBe(false);
-
-    app.loadAppSettingsFromStorage = () => ({ terminalWheelLocalScrollback: false });
-    app.sessions = new Map([['sess-1', { mode: 'codex' }]]);
-    expect(app._shouldForwardTouchScrollToApp()).toBe(false);
-  });
-
   it('wheel: the local-scrollback opt-out pins the plain wheel to local scrollback (issue #154)', () => {
     const { app } = loadTerminalUiHarness();
     app.activeSessionId = 'sess-1';

--- a/test/terminal-touch-tap.test.ts
+++ b/test/terminal-touch-tap.test.ts
@@ -75,7 +75,7 @@ function createElementHarness() {
   };
 }
 
-function createTerminalGrid(lines: string[], cursorY: number) {
+function createTerminalGrid(lines: string[], cursorY: number, wrappedRows = new Set<number>()) {
   const textarea = {
     classList: { contains: (name: string) => name === 'xterm-helper-textarea' },
     blur: vi.fn(),
@@ -90,7 +90,9 @@ function createTerminalGrid(lines: string[], cursorY: number) {
         baseY: 0,
         cursorY,
         getLine: (row: number) =>
-          row >= 0 && row < lines.length ? { translateToString: () => lines[row] } : undefined,
+          row >= 0 && row < lines.length
+            ? { isWrapped: wrappedRows.has(row), translateToString: () => lines[row] }
+            : undefined,
       },
     },
     element: {
@@ -129,6 +131,19 @@ describe('terminal touch tap mouse guard', () => {
     expect(app._classifyMobileTerminalTap(9, 17)).toBe('content'); // row 2: readback
     expect(app._classifyMobileTerminalTap(9, 65)).toBe('input'); // row 5: prompt
     expect(app._classifyMobileTerminalTap(9, 81)).toBe('content'); // row 6: status
+  });
+
+  it('classifies Claude background-agent status as content rather than keyboard input', () => {
+    const { app } = loadTerminalUiHarness();
+    app.activeSessionId = 'sess-1';
+    app.sessions = new Map([['sess-1', { mode: 'claude', cliVersion: '2.1.220' }]]);
+    app.terminal = createTerminalGrid(
+      ['', '', '', '• Working (1m 50s • esc to ', 'interrupt) · 1 background teammate', ''],
+      4,
+      new Set([4])
+    );
+
+    expect(app._classifyMobileTerminalTap(9, 65)).toBe('content');
   });
 
   it('treats a highlighted numbered choice as TUI content, not an input prompt', () => {
@@ -516,6 +531,25 @@ describe('terminal touch tap mouse guard', () => {
 
     app.sessions = new Map([['sess-1', { mode: 'gemini', cliVersion: '9.9.9' }]]); // unverified TUI
     expect(app._shouldForwardWheelToApp({ shiftKey: false })).toBe(false);
+  });
+
+  it('touch: forwards verified Claude transcript scrolling but keeps Codex touch in local history', () => {
+    const { app } = loadTerminalUiHarness();
+    app.activeSessionId = 'sess-1';
+    app.terminal = {
+      modes: { mouseTrackingMode: 'none' },
+      buffer: { active: { viewportY: 50, baseY: 50 } },
+    };
+
+    app.sessions = new Map([['sess-1', { mode: 'claude', cliVersion: '2.1.220' }]]);
+    expect(app._shouldForwardTouchScrollToApp()).toBe(true);
+
+    app.loadAppSettingsFromStorage = () => ({ terminalWheelLocalScrollback: true });
+    expect(app._shouldForwardTouchScrollToApp()).toBe(false);
+
+    app.loadAppSettingsFromStorage = () => ({ terminalWheelLocalScrollback: false });
+    app.sessions = new Map([['sess-1', { mode: 'codex' }]]);
+    expect(app._shouldForwardTouchScrollToApp()).toBe(false);
   });
 
   it('wheel: the local-scrollback opt-out pins the plain wheel to local scrollback (issue #154)', () => {


### PR DESCRIPTION
Reopening #186 on its own branch, rebased on current master, as you suggested in #173.

This is the one you said you wanted most, and it now carries the fix for the blocker you reduced — the keyboard being unreachable — rather than just the tap routing.

## The blocker, fixed

You reported that tapping the terminal on a phone no longer raises the keyboard, so there is no way to type. That was real, and it was still present on my rebased branch until the last commit here.

Measured by dispatching real `touchstart`/`touchend` events against a running server, iPhone-class viewport (390×844), claude-mode session, tapping the middle of the terminal:

| | `document.activeElement` after the tap |
| --- | --- |
| master `b1614e8` | `textarea.xterm-helper-textarea` |
| this branch, before the fix commit | `body` |
| this branch, now | `textarea.xterm-helper-textarea` |

**Mechanism**, matching your reduction exactly: `_classifyMobileTerminalTap()` returns `content` for any non-prompt row, so `_handleMobileTerminalTap()` called `_blurMobileTerminalInput()`, while `touchstart`'s `preventDefault()` had already cancelled the compatibility click that would otherwise focus xterm. Both routes to focus closed on the same gesture.

## Why the blur could not simply be deleted

Two existing tests in `test/mobile/keyboard.test.ts` assert the blur, and they encode correct behaviour: tapping a collapsible readback or a `• Working (… esc to interrupt)` status row acts on the CLI, and popping the keyboard there is wrong. Your repro taps an inert transcript row, where the only sensible outcome is "let me type". Both classified as `content` and were treated identically — that conflation was the actual defect.

The fix distinguishes them by the **affordance the CLI prints** (`ctrl+r to expand`, `tap to collapse`, `esc to interrupt`) rather than by row titles. Titles vary per CLI and per version; the affordance is what makes a row actionable in the first place. Since the hint sits on its own row and a finger lands on the title, the adjacent row is consulted too.

I mention this because my first attempt keyed on title strings (`Agent readback`, `Tool result`) taken from the test fixtures. The full suite passed, and a realistically-worded codex readback (`Read src/foo.ts (120 lines)` / `ctrl+r to expand`) still swallowed the keyboard. It matched the fixtures, not the behaviour. Caught by probing a readback whose wording differs from the tests.

## On the test you asked for

You asked for a test asserting a tap ends with `document.activeElement === terminal.textarea`. It is here, dispatching a real gesture via `page.touchscreen.tap`.

**In fairness, it is not red on master.** Master does not have this bug, so the assertion is green there. It is a regression guard for this branch, not evidence against master. I would rather say that plainly than let the table above imply a comparison it does not support.

The same caveat applies to the unit tests in `test/terminal-touch-tap.test.ts`: 8 of 27 fail on master, but with `TypeError: ... is not a function`, because the methods are new. That only proves absence, not wrong output.

One methodological note that may be worth having in the repo: calling `_handleMobileTerminalTap()` directly reports the correct intent and looks fine, because it bypasses the `touchstart` `preventDefault()`. Only a dispatched touch gesture reproduces the bug. Any focus test here has to go through real events.

## Verification

Against master `b1614e8`:

```
npx tsc --noEmit                                  clean
test/terminal-touch-tap.test.ts                   27 passed (27)
npm run test:mobile -- test/mobile/keyboard.test.ts   5 failed | 35 passed (40)
```

The 5 failures are pre-existing and identical on master (stale layout/accessory-bar expectations and a CJK timeout); they are untouched here. Full mobile suite, this branch vs pristine master on the same machine: **both 54 failed**, identical per-file counts, branch running 356 tests to master's 352 — the added tests pass and nothing regresses.

## Coexistence with #205

The touch-forwarding path added in #205 is unchanged. Drag gestures still route through `_shouldForwardTouchScrollToApp()` — forwarded as SGR wheel events for verified Claude versions, local xterm scrollback otherwise. This PR only changes what happens on a **tap** (no scroll), and only which rows dismiss the keyboard. The SGR mouse report a content tap sends is byte-identical to before; the readback test still asserts exactly one report of the form `\x1b[<0;N;1M\x1b[<0;N;1m`.

## Scope

3 files. `src/web/public/terminal-ui.js` plus the two test files. No changes to any guard or policy test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
