### PR TITLE
fix(paths): one home-prefix helper, so path labels abbreviate on Linux and macOS

### DIFF
--- a/src/web/public/session-ui.js
+++ b/src/web/public/session-ui.js
@@ -489,7 +489,11 @@ Object.assign(CodemanApp.prototype, {
         const date = new Date(s.lastModified);
         const timeStr = date.toLocaleDateString('en', { month: 'short', day: 'numeric' })
           + ' ' + date.toLocaleTimeString('en', { hour: '2-digit', minute: '2-digit', hour12: false });
-        const shortDir = s.workingDir.replace(/^\/home\/[^/]+\//, '~/');
+        // Shared helper, not a local regex: the copy that used to live here
+        // matched `/home/<user>/` only, so on macOS every row rendered the same
+        // unabbreviated `/Users/<user>/…` prefix and ellipsized away the tail
+        // that identifies it (#273).
+        const shortDir = this._shortenHomePath(s.workingDir);
 
         const btn = document.createElement('button');
         btn.className = 'run-mode-option';
@@ -2676,7 +2680,9 @@ Object.assign(CodemanApp.prototype, {
     cases.forEach((c, idx) => {
       const isFirst = idx === 0;
       const isLast = idx === cases.length - 1;
-      const pathDisplay = c.path ? c.path.replace(/^\/Users\/[^/]+/, '~') : '';
+      // Was `/Users/<user>` only, the mirror image of the Run menu's bug: every
+      // case path on a Linux host rendered in full, unabbreviated.
+      const pathDisplay = c.path ? this._shortenHomePath(c.path) : '';
       html += `
         <div class="case-manage-item" data-case="${escapeHtml(c.name)}">
           <div class="case-manage-info">

--- a/src/web/public/terminal-ui.js
+++ b/src/web/public/terminal-ui.js
@@ -1610,11 +1610,21 @@ Object.assign(CodemanApp.prototype, {
     return workingDir.split('/').pop() || workingDir;
   },
 
-  /** Normalize home prefixes to "~/" on both Linux and macOS */
+  /**
+   * Normalize a home prefix to "~" on both Linux (`/home/<user>`) and macOS
+   * (`/Users/<user>`). The lookahead lets the home directory ITSELF match, so a
+   * path that is exactly `$HOME` renders "~" instead of being left raw.
+   *
+   * This is the only place that pattern belongs. Two hand-rolled copies had
+   * drifted, each broken on the platform its author was not using: the Run
+   * menu's matched `/home/` only, so on macOS nothing was stripped and every
+   * Recent Sessions row spent its first ~19 characters on an identical
+   * `/Users/<user>/` prefix (#273); the case-manage list's matched `/Users/`
+   * only, so no Linux path was ever abbreviated there. Route new path labels
+   * through here rather than writing a third copy.
+   */
   _shortenHomePath(p) {
-    return (p || '')
-      .replace(/^\/home\/[^/]+\//, '~/')
-      .replace(/^\/Users\/[^/]+\//, '~/');
+    return (p || '').replace(/^\/(?:home|Users)\/[^/]+(?=\/|$)/, '~');
   },
 
   /**

--- a/test/home-path-abbreviation.test.ts
+++ b/test/home-path-abbreviation.test.ts
@@ -1,0 +1,166 @@
+/**
+ * @fileoverview Issue #273 and its mirror image: abbreviating `$HOME` in path labels.
+ *
+ * The rule ("show `~/project` rather than `/home/<user>/project`") had three
+ * implementations in the frontend, and two of them were platform-specific in
+ * opposite directions, so each looked correct to whoever wrote it:
+ *
+ *   - the Run menu's Recent Sessions rows matched `/home/<user>/` only, so on
+ *     macOS nothing was stripped, every row spent its first ~19 characters on an
+ *     identical `/Users/<user>/` prefix, and the left-to-right ellipsis removed
+ *     the tail that identifies the row (#273),
+ *   - the case-manage list matched `/Users/<user>` only, so on a Linux host no
+ *     case path was ever abbreviated at all.
+ *
+ * Both now call `_shortenHomePath()`, which is pinned here for both layouts, and
+ * a static guard fails if a fourth copy of the pattern appears.
+ *
+ * Loaded via `vm` against a stub CodemanApp with a fake DOM, same harness as
+ * history-list-controls.test.ts. Port: none (no browser, no server).
+ */
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import vm from 'node:vm';
+import { describe, expect, it, vi } from 'vitest';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+const PUBLIC = resolve(import.meta.dirname, '../src/web/public');
+
+/**
+ * The container the vm's `document.getElementById` resolves for the case list.
+ * Swapped per test: the closure lives in THIS realm, so the shipping code inside
+ * the vm reads whatever the current test installed.
+ */
+let currentCaseList: { innerHTML: string } | null = null;
+
+function loadTerminalUiPrototype(): Record<string, any> {
+  const source = readFileSync(resolve(PUBLIC, 'terminal-ui.js'), 'utf8');
+  const context = vm.createContext({
+    console,
+    CodemanApp: class CodemanApp {},
+    setInterval: vi.fn(),
+    clearInterval: vi.fn(),
+    setTimeout,
+    clearTimeout,
+    requestAnimationFrame: vi.fn(),
+    document: { addEventListener: vi.fn(), getElementById: () => null, createElement: () => ({}) },
+    window: { addEventListener: vi.fn(), removeEventListener: vi.fn() },
+  });
+  vm.runInContext(`${source}\nglobalThis.__proto = CodemanApp.prototype;`, context);
+  return (context as unknown as { __proto: Record<string, any> }).__proto;
+}
+
+function loadSessionUiPrototype(): Record<string, any> {
+  const source = readFileSync(resolve(PUBLIC, 'session-ui.js'), 'utf8');
+  const context = vm.createContext({
+    console,
+    CodemanApp: class CodemanApp {},
+    VoiceInput: {},
+    escapeHtml: (t: unknown) => String(t ?? ''),
+    setTimeout,
+    clearTimeout,
+    localStorage: { getItem: () => null, setItem: () => {} },
+    document: { getElementById: (id: string) => (id === 'caseManageList' ? currentCaseList : null) },
+    window: { addEventListener: vi.fn() },
+  });
+  vm.runInContext(`${source}\nglobalThis.__proto = CodemanApp.prototype;`, context);
+  return (context as unknown as { __proto: Record<string, any> }).__proto;
+}
+
+const terminalProto = loadTerminalUiPrototype();
+const sessionProto = loadSessionUiPrototype();
+const shorten = (p: unknown) => terminalProto._shortenHomePath.call(terminalProto, p);
+
+describe('_shortenHomePath', () => {
+  it('abbreviates the Linux home prefix', () => {
+    expect(shorten('/home/arkon/default/claudeman')).toBe('~/default/claudeman');
+  });
+
+  it('abbreviates the macOS home prefix, which the Run menu never did (#273)', () => {
+    expect(shorten('/Users/jordanryan/code/facet/facet-agency-ops')).toBe('~/code/facet/facet-agency-ops');
+  });
+
+  it('abbreviates the home directory itself, not only paths below it', () => {
+    // The case-manage list's old regex had no trailing slash and did collapse
+    // this to "~"; keep that, or a case whose path IS $HOME would regress.
+    expect(shorten('/home/arkon')).toBe('~');
+    expect(shorten('/Users/jordanryan')).toBe('~');
+  });
+
+  it('leaves paths that only look like a home prefix alone', () => {
+    expect(shorten('/homer/bob/x')).toBe('/homer/bob/x');
+    expect(shorten('/Userspace/bob/x')).toBe('/Userspace/bob/x');
+    expect(shorten('/home')).toBe('/home');
+    expect(shorten('/mnt/d/work')).toBe('/mnt/d/work');
+    expect(shorten('/opt/codeman')).toBe('/opt/codeman');
+  });
+
+  it('replaces only the leading occurrence', () => {
+    expect(shorten('/home/arkon/home/bob/x')).toBe('~/home/bob/x');
+  });
+
+  it('tolerates empty and missing input', () => {
+    expect(shorten('')).toBe('');
+    expect(shorten(undefined)).toBe('');
+    expect(shorten(null)).toBe('');
+  });
+});
+
+describe('renderCaseManageList path labels', () => {
+  function render(cases: Array<{ name: string; path: string; location?: string }>): string {
+    currentCaseList = { innerHTML: '' };
+    const app: any = {
+      cases,
+      _shortenHomePath: terminalProto._shortenHomePath,
+      renderCaseManageList: sessionProto.renderCaseManageList,
+    };
+    app.renderCaseManageList();
+    const html = currentCaseList.innerHTML;
+    currentCaseList = null;
+    return html;
+  }
+
+  it('abbreviates a Linux case path (the mirror of #273)', () => {
+    const html = render([{ name: 'demo', path: '/home/arkon/codeman-cases/demo' }]);
+    expect(html).toContain('~/codeman-cases/demo');
+    expect(html).not.toContain('/home/arkon/codeman-cases/demo');
+  });
+
+  it('still abbreviates a macOS case path', () => {
+    const html = render([{ name: 'demo', path: '/Users/jordanryan/codeman-cases/demo' }]);
+    expect(html).toContain('~/codeman-cases/demo');
+    expect(html).not.toContain('/Users/jordanryan/codeman-cases/demo');
+  });
+
+  it('renders the row when a case has no path at all', () => {
+    const html = render([{ name: 'demo', path: '' }]);
+    expect(html).toContain('demo');
+    expect(html).toContain('class="case-manage-path"');
+  });
+});
+
+describe('single implementation of the home-prefix rule', () => {
+  /** Every top-level frontend module (vendor/ and subdirs are not ours). */
+  const sources = readdirSync(PUBLIC)
+    .filter((name) => name.endsWith('.js'))
+    .map((name) => ({ name, text: readFileSync(resolve(PUBLIC, name), 'utf8') }));
+
+  it('has exactly one home-prefix regex, in terminal-ui.js', () => {
+    // Any regex literal anchored at a home root. Three of these had drifted
+    // apart; a fourth would drift the same way.
+    const pattern = /\/\^\\\/(?:\(\?:home\|Users\)|home|Users)\\\//g;
+    const hits = sources.flatMap(({ name, text }) => (text.match(pattern) ?? []).map(() => name));
+    expect(hits).toEqual(['terminal-ui.js']);
+  });
+
+  it('routes both session-ui path labels through the helper', () => {
+    // Deliberately counts calls rather than pinning source lines: the Run menu
+    // row is being restructured in #274, and this guard should survive that as
+    // long as the label still goes through the helper.
+    const sessionUi = sources.find((s) => s.name === 'session-ui.js')!.text;
+    const calls = sessionUi.match(/this\._shortenHomePath\(/g) ?? [];
+    expect(calls.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/test/run-mode-ui.test.ts
+++ b/test/run-mode-ui.test.ts
@@ -760,6 +760,11 @@ describe('case selector refresh', () => {
     ];
     app.showToast = vi.fn();
 
+    // deleteCase re-renders the case-manage list, whose path label goes through
+    // _shortenHomePath. That method lives in terminal-ui.js, which this harness
+    // does not load (the real app always has it: load order 7 before 12).
+    app._shortenHomePath = (p: string) => p;
+
     await app.deleteCase('deleted-case');
 
     expect(quickStartCase.blur).toHaveBeenCalled();


### PR DESCRIPTION
Two bugs with one cause: the rule "show `~/project` rather than `/home/<user>/project`" had three implementations in the frontend, and two of them were platform-specific in **opposite** directions, so each looked correct to whoever wrote it.

## The two symptoms

**Run menu, Recent Sessions (#273, reported by @jordan8037310).** The row label matched `/home/<user>/` only:

```js
const shortDir = s.workingDir.replace(/^\/home\/[^/]+\//, '~/');
```

On macOS nothing was stripped, so every row spent its first ~19 characters on an identical `/Users/<user>/` prefix and the left-to-right ellipsis removed the tail that identifies the row. His report also traced why the menu felt too narrow: the `max-width: 250px` comment justifies that number as "the width at which the common `~/<dir>/<repo>` + timestamp recent-session row still fits whole", which only holds if the abbreviation actually ran.

**Manage Cases list, the mirror image.** Unreported, and the one that bites on Linux:

```js
const pathDisplay = c.path ? c.path.replace(/^\/Users\/[^/]+/, '~') : '';
```

macOS-only, so on a Linux host every case path rendered in full. Measured on this box: 0 of 27 rows abbreviated.

## The fix

Both call sites now go through `_shortenHomePath()`, which was already correct for both layouts and already backs the Resume list, Cmd+K, the desktop home rail and the phone overview. Its body collapses to one alternation with a lookahead:

```js
_shortenHomePath(p) {
  return (p || '').replace(/^\/(?:home|Users)\/[^/]+(?=\/|$)/, '~');
}
```

The lookahead is what lets the home directory *itself* match, so a case whose path is exactly `$HOME` renders `~` rather than being left raw. That preserves what the case-manage list did on macOS, where its regex had no trailing slash.

No behaviour change for any existing caller: `/home/u/x` and `/Users/u/x` both still yield `~/x`, and paths that only look like a home root (`/homer/bob`, `/Userspace/bob`, `/home`) are still left alone.

## Tests

`test/home-path-abbreviation.test.ts` (new, 11 cases, runs in CI) loads the real modules in a `vm` and pins:

- the helper on both layouts, the bare `$HOME` case, look-alike prefixes, leading-occurrence-only replacement, and empty/`null` input,
- the rendered `renderCaseManageList()` label for a Linux path and a macOS one,
- a static guard that `src/web/public` contains **exactly one** home-prefix regex, in `terminal-ui.js`. A fourth copy fails the build, which is the only thing that stops this drifting again.

4 of the 11 fail without the source change.

`test/run-mode-ui.test.ts` gains a `_shortenHomePath` stub: its harness loads `session-ui.js` without `terminal-ui.js`, so the new helper call threw there. The real app always has the method (load order 7 before 12), so the harness was the artificial half, not the production code.

`npm run test:ci`: 4875 passed, 12 skipped. `tsc --noEmit`, eslint, `format:check`, `check:frontend-syntax` and `check:public-assets` all clean.

## Verification

Browser-driven at 1400x900 against an isolated instance (`CODEMAN_INSTANCE` + its own tmux socket, so no live session was touched), reading back real data: 27 cases and 50 history rows.

| surface | before | after |
|---|---|---|
| Manage Cases paths | 0 of 27 abbreviated | 27 of 27 |
| Run menu rows | (Linux was already fine) | 17 of 20 abbreviated, 0 still carrying a home prefix |

The remaining 3 Run menu rows are `/tmp/...` paths, which correctly stay raw. Tooltips still carry the full path. No page errors.

## Interaction with #274

#274 fixes the same `#273` symptom in the Run menu by adding a corrected regex inline, and restructures that row (leading folder name, trailing dimmed parent, worktree pill). The two overlap on one line of `session-ui.js`.

Either merge order works. If #274 goes first, resolve by keeping its row structure and calling `this._shortenHomePath(...)` for the label instead of its inline regex; the static guard in this PR then keeps that honest. The Run-menu assertion here deliberately counts helper calls rather than pinning a source line, so it survives that restructure. Nothing in this PR touches the width or worktree-pill work, which is #274's alone.
