### PR TITLE
Ralph loop silently stops polling after two ticks

### DIFF
--- a/src/ralph-loop.ts
+++ b/src/ralph-loop.ts
@@ -281,7 +281,14 @@ export class RalphLoop extends EventEmitter {
         // Guard: only reschedule if still running AND no timer is pending
         // (prevents race where stop() clears timer between our check and setTimeout)
         if (this._status === 'running' && this.loopTimer === null) {
-          this.loopTimer = setTimeout(() => this.runLoop(), this.pollIntervalMs);
+          // Null the handle when the timer fires, BEFORE re-entering runLoop —
+          // otherwise the `loopTimer === null` guard above stays false on the
+          // next pass and the loop stops rescheduling after 2 ticks.
+          // Mirrors the orchestrator-loop reschedule pattern.
+          this.loopTimer = setTimeout(() => {
+            this.loopTimer = null;
+            this.runLoop();
+          }, this.pollIntervalMs);
         }
       });
   }

--- a/test/ralph-loop.test.ts
+++ b/test/ralph-loop.test.ts
@@ -129,6 +129,36 @@ describe('RalphLoop', () => {
     vi.useRealTimers();
   });
 
+  describe('reschedule loop (regression)', () => {
+    // tick() is the only path that calls setRalphLoopState with lastCheckAt and
+    // no status field; start() carries status:'running', stop() status:'stopped'.
+    const countTicks = () =>
+      (mockState.store.setRalphLoopState as any).mock.calls.filter(
+        (c: any[]) => c[0]?.lastCheckAt !== undefined && c[0]?.status === undefined
+      ).length;
+
+    it('keeps rescheduling past the second tick', async () => {
+      // Real timers + a tiny poll interval: tick()'s async internals settle
+      // naturally on the event loop, avoiding fake-timer microtask fragility.
+      vi.useRealTimers();
+      loop.destroy();
+      // Keep the loop in the "running, should keep polling" state so it actually
+      // exercises the reschedule path: min duration unreached + autoGenerate on
+      // makes shouldStop() false (idle sessions are mocked empty, so nothing is
+      // actually generated). Otherwise an empty queue self-stops after 1 tick.
+      loop = new RalphLoop({ pollIntervalMs: 5, minDurationMs: 60_000, autoGenerateTasks: true });
+
+      await loop.start();
+      await new Promise((resolve) => setTimeout(resolve, 80)); // ~16 poll intervals
+      loop.stop();
+
+      // The bug: the loopTimer handle is never nulled in the setTimeout callback,
+      // so the `loopTimer === null` reschedule guard is false after the first fire
+      // and the loop dies at exactly 2 ticks. Fixed -> many ticks.
+      expect(countTicks()).toBeGreaterThanOrEqual(3);
+    });
+  });
+
   describe('initial state', () => {
     it('should start in stopped status', () => {
       expect(loop.status).toBe('stopped');
@@ -296,11 +326,7 @@ describe('RalphLoop', () => {
   describe('getStats', () => {
     it('should return complete stats object', async () => {
       const mockRunningTask = { id: '2', status: 'running', isTimedOut: () => false };
-      mockState.taskQueue.tasks = [
-        { id: '1', status: 'pending' },
-        mockRunningTask,
-        { id: '3', status: 'completed' },
-      ];
+      mockState.taskQueue.tasks = [{ id: '1', status: 'pending' }, mockRunningTask, { id: '3', status: 'completed' }];
       mockState.taskQueue.getRunningTasks.mockReturnValue([mockRunningTask]);
 
       await loop.start();


### PR DESCRIPTION
## The bug

`runLoop()`'s reschedule guard is:

```ts
if (this._status === 'running' && this.loopTimer === null) {
  this.loopTimer = setTimeout(() => this.runLoop(), this.pollIntervalMs);
}
```

The timer callback never nulls `loopTimer`. So from the first fire onward the handle stays non-null, the `loopTimer === null` guard is false on every subsequent pass, and the loop stops rescheduling after **exactly two ticks**.

The failure is silent, which is what makes it easy to miss on a long autonomous run:

- `status` remains `running`
- `stop()` is never called
- nothing throws and nothing is logged

The loop simply never runs again.

## The fix

Null the handle inside the callback, before re-entering `runLoop()`. This is the pattern `orchestrator-loop.ts` already uses for its own reschedule, so the two loops now behave the same way.

## Test

A regression case in `test/ralph-loop.test.ts` runs a real 5 ms-interval loop for ~16 intervals and asserts at least 3 ticks.

It uses real timers rather than fake ones on purpose — `tick()`'s async internals settle on the event loop, and fake timers made the assertion fragile around microtask ordering.

Verified against the unfixed source: it reports **exactly 2**, i.e. `expected 2 to be greater than or equal to 3`. So the test pins the real bug rather than merely passing alongside the fix.

Full gate green: `tsc --noEmit`, eslint, prettier, and `vitest run --config config/vitest.ci.config.ts` (5368 passed / 12 skipped).