### PR TITLE
fix(ui): show inline rename text in session sidebar

### DIFF
--- a/src/web/public/styles.css
+++ b/src/web/public/styles.css
@@ -1535,7 +1535,10 @@ html[data-tab-orientation='vertical'] .tab-rail .session-tab .tab-name-prefix {
   display: inline;
 }
 
-html[data-tab-orientation='vertical'] .tab-rail .session-tab .tab-name.tab-name-renaming {
+:is(
+  html[data-tab-orientation='vertical'] .tab-rail,
+  html[data-session-list='sidebar'] .session-sidebar
+) .session-tab .tab-name.tab-name-renaming {
   display: flex;
   align-items: center;
   -webkit-box-orient: initial;
@@ -1544,11 +1547,17 @@ html[data-tab-orientation='vertical'] .tab-rail .session-tab .tab-name.tab-name-
   overflow: visible;
 }
 
-html[data-tab-orientation='vertical'] .tab-name-renaming .tab-rename-prefix {
+:is(
+  html[data-tab-orientation='vertical'] .tab-rail,
+  html[data-session-list='sidebar'] .session-sidebar
+) .tab-name-renaming .tab-rename-prefix {
   flex: 0 0 auto;
 }
 
-html[data-tab-orientation='vertical'] .tab-name-renaming .tab-rename-input {
+:is(
+  html[data-tab-orientation='vertical'] .tab-rail,
+  html[data-session-list='sidebar'] .session-sidebar
+) .tab-name-renaming .tab-rename-input {
   flex: 1 1 0;
   width: auto;
   min-width: 0;

--- a/test/inline-rename.test.ts
+++ b/test/inline-rename.test.ts
@@ -541,6 +541,46 @@ describe('Inline rename input', () => {
     expect(result.firstRenameClassActive).toBe(false);
   });
 
+  it('Session sidebar paints typing without ellipsizing the live editor', async () => {
+    await resetState();
+    const id = 'sidebar-live-input';
+
+    await page.evaluate((sessionId) => {
+      const app = (
+        window as unknown as {
+          app: {
+            sessions: Map<string, { id: string; name: string }>;
+            startInlineRename: (id: string) => void;
+          };
+        }
+      ).app;
+      document.documentElement.dataset.sessionList = 'sidebar';
+      document.documentElement.dataset.sidebar = 'expanded';
+      const list = document.getElementById('sessionSidebarList') as HTMLElement;
+      const tab = document.createElement('div');
+      tab.setAttribute('data-test-tab', '1');
+      tab.className = 'session-tab';
+      tab.innerHTML =
+        '<span class="tab-info"><span class="tab-name-row">' +
+        `<span class="tab-name" data-session-id="${sessionId}">old title</span>` +
+        '</span></span>';
+      list.appendChild(tab);
+      app.sessions.set(sessionId, { id: sessionId, name: 'old title' });
+      app.startInlineRename(sessionId);
+    }, id);
+
+    const label = page.locator(`.tab-name[data-session-id="${id}"]`);
+    const input = label.locator('input.tab-rename-input');
+    await input.press(process.platform === 'darwin' ? 'Meta+A' : 'Control+A');
+    await page.keyboard.type('edited title');
+
+    expect(await input.inputValue()).toBe('edited title');
+    expect(await input.evaluate((node) => document.activeElement === node)).toBe(true);
+    expect(await label.evaluate((node) => node.classList.contains('tab-name-renaming'))).toBe(true);
+    expect(await label.evaluate((node) => getComputedStyle(node).overflow)).toBe('visible');
+    expect(await input.evaluate((node) => node.getBoundingClientRect().width)).toBeGreaterThan(0);
+  });
+
   it('Vertical rail paints typing in an unclamped editor and restores the clamp on cancel', async () => {
     await resetState();
     const id = 'vertical-live-input';


### PR DESCRIPTION
## Summary

- apply the live rename editor layout to the session sidebar as well as the vertical tab rail
- prevent the sidebar tab label's ellipsis paint from hiding the focused input
- add a Chromium regression test covering visible, focused sidebar typing

## Verification

- `npm run test:browser -- test/inline-rename.test.ts` (14 passed)
- `npm test` (316 files passed, 6,185 tests passed)
- `npm run typecheck`
- `npm run lint`
- `npm run check:frontend-syntax`
- `npm run check:public-assets`
- `npm run format:check`
- manually verified the rich sidebar in Chromium: typed text and caret render in the focused editor