### PR TITLE
fix(docker): install pnpm for DeepSeek profile

### DIFF
--- a/docker/agent.Dockerfile
+++ b/docker/agent.Dockerfile
@@ -75,8 +75,9 @@ RUN curl -fsSL https://x.ai/cli/install.sh | bash \
 # profile itself is installed further down, into the `agent` HOME, because
 # Codeman deliberately does NOT seed `profiles/` from the host: it is a
 # per-profile node_modules tree, host-arch-specific and far too large to copy on
-# every container start.
-RUN npm install -g @deepseek-ai/dsh \
+# every container start. The harness delegates profile dependency management to
+# pnpm, so pnpm is a build dependency rather than optional runtime tooling.
+RUN npm install -g @deepseek-ai/dsh pnpm \
  && npm cache clean --force \
  && dsh --version
 
@@ -110,6 +111,10 @@ RUN useradd -g 0 -m -d /home/agent -s /bin/bash agent \
  && mkdir -p /home/agent/.npm /home/agent/.cache /home/agent/.config /home/agent/.codeman \
       /home/agent/.claude/projects /home/agent/.codex/sessions /home/agent/.pi/agent /home/agent/.grok \
       /home/agent/.dsh \
+ && DSH_HOME=/home/agent/.dsh HOME=/home/agent \
+      dsh plugin --profile dsh-tui install --ignore-scripts \
+ && printf '%s\n' '' 'allowBuilds:' '  "@google/genai": true' '  protobufjs: true' \
+      >> /home/agent/.dsh/profiles/dsh-tui/pnpm-workspace.yaml \
  && DSH_HOME=/home/agent/.dsh HOME=/home/agent \
       dsh plugin --profile dsh-tui add @deepseek-harness-tui/dsh-tui \
  && test -f /home/agent/.dsh/profiles/dsh-tui/package.json \


### PR DESCRIPTION
## What

Restore clean builds of the Docker agent base image by installing pnpm and preparing the DeepSeek Harness TUI profile with its required lifecycle-script allow-list.

This preserves Codeman's ability to auto-build `codeman/agent:base` and then spawn isolated case containers when the base image is not already present.

## When

The failure was reproduced on 27 August 2026 against upstream `master` at `7dfb4acf` with a no-cache, pull-enabled build:

```bash
docker build --progress=plain --no-cache --pull --file docker/agent.Dockerfile .
```

The build stopped while adding the DeepSeek TUI profile with exit code 127:

```text
dsh: pnpm not found on PATH — install pnpm to manage profile plugins
```

## Why

`@deepseek-ai/dsh` delegates profile dependency management to pnpm. The Dockerfile installed the `dsh` CLI but did not install pnpm, so `dsh plugin --profile dsh-tui add ...` could not complete.

Because Codeman normally auto-builds this base image on the first isolated Docker case, a clean host could not create its first isolated agent container after the image build failed.

pnpm also controls dependency lifecycle scripts through the profile workspace configuration. The DeepSeek TUI dependency tree requires the `@google/genai` preinstall and `protobufjs` postinstall scripts during profile installation.

## How

- Install pnpm alongside `@deepseek-ai/dsh` as an image build dependency.
- Initialise the `dsh-tui` profile with lifecycle scripts disabled.
- Add a profile-local `allowBuilds` policy for `@google/genai` and `protobufjs`.
- Add `@deepseek-harness-tui/dsh-tui` after the policy exists, allowing only those required scripts to run.
- Retain the existing profile existence and ownership checks.

## Validation

- Confirmed the original no-cache image build fails with the missing-pnpm error.
- Confirmed the fixed no-cache, pull-enabled image build completes successfully.
- Confirmed the resulting image runs as the non-root `agent` user and contains pnpm 11.24.0, dsh 0.1.1-rc.2, and `@deepseek-harness-tui/dsh-tui` 0.9.3.
- Confirmed an arbitrary runtime UID can write to the prepared Codeman home directory.
- `npm run typecheck` passed.
- `npm run lint` passed.
- `npm run format:check` passed.
- `npm run check:frontend-syntax` passed for all 34 frontend JavaScript files.
- `npm test` passed: 6,283 passed and 12 skipped across 318 test files.