### PR TITLE
feat(models): add direct Fable 5.1 selection

### DIFF
--- a/docs/wiki/Settings-Reference.md
+++ b/docs/wiki/Settings-Reference.md
@@ -82,7 +82,8 @@ every session or only the active tab.
 
 Claude model cards, the 1M context window switch, and the thinking effort segment. The cards
 and the switch compose into one model choice, so there is no separate "which one wins"
-question.
+question. Fable 5.1 is selectable directly and includes its 1M context window by default;
+the switch remains for the older Fable 5, Opus, and Opus 4.6 `[1m]` variants.
 
 Model and effort are both **soft defaults**: the model is written into the case's
 `.claude/settings.local.json` and effort is passed at start, so `/model` and `/effort`

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -2028,6 +2028,7 @@
                   <div class="set-modelgrid" id="appSettingsModelCards" role="radiogroup" aria-label="Model for new Claude sessions" data-search="model opus sonnet haiku fable claude"></div>
                   <select id="appSettingsClaudeModel" class="set-select set-field-hidden" aria-hidden="true" tabindex="-1">
                     <option value="" data-meta="Whatever the CLI picks">Default (CLI setting)</option>
+                    <option value="claude-fable-5-1" data-meta="Latest · 1M context" data-base="claude-fable-5-1" data-ctx-default="1">Fable 5.1</option>
                     <option value="claude-fable-5" data-meta="Most powerful" data-base="claude-fable-5" data-ctx="1">Fable 5</option>
                     <option value="claude-fable-5[1m]" data-variant="1m" data-base="claude-fable-5">Fable 5 (1M context)</option>
                     <option value="opus" data-meta="Most capable" data-base="opus" data-ctx="1">Opus</option>
@@ -2040,7 +2041,7 @@
                   <div class="set-row" id="appSettingsContextRow" data-search="1m context window opus long">
                     <div class="set-row-text">
                       <span class="set-row-label">1M context window</span>
-                      <span class="set-row-desc" id="appSettingsContextDesc">Available for Fable 5, Opus and Opus 4.6.</span>
+                      <span class="set-row-desc" id="appSettingsContextDesc">Fable 5.1 includes a 1M context window by default. Fable 5, Opus and Opus 4.6 can switch it on.</span>
                     </div>
                     <label class="switch switch-sm"><input type="checkbox" id="appSettingsOpusContext1m"><span class="slider"></span></label>
                   </div>
@@ -2080,6 +2081,7 @@
                     </div>
                     <select id="appSettingsDefaultModel" class="set-select">
                       <option value="">Default (CLI default)</option>
+                      <option value="claude-fable-5-1">Fable 5.1 (Latest · 1M context)</option>
                       <option value="claude-fable-5">Fable 5 (Most powerful)</option>
                       <option value="opus">Opus (Most capable)</option>
                       <option value="sonnet">Sonnet (Balanced)</option>
@@ -2094,6 +2096,7 @@
                         <option value="haiku">Haiku</option>
                         <option value="sonnet">Sonnet</option>
                         <option value="opus">Opus</option>
+                        <option value="claude-fable-5-1">Fable 5.1</option>
                         <option value="claude-fable-5">Fable 5</option>
                       </select>
                     </div>
@@ -2104,6 +2107,7 @@
                         <option value="haiku">Haiku</option>
                         <option value="sonnet">Sonnet</option>
                         <option value="opus">Opus</option>
+                        <option value="claude-fable-5-1">Fable 5.1</option>
                         <option value="claude-fable-5">Fable 5</option>
                       </select>
                     </div>
@@ -2114,6 +2118,7 @@
                         <option value="haiku">Haiku</option>
                         <option value="sonnet">Sonnet</option>
                         <option value="opus">Opus</option>
+                        <option value="claude-fable-5-1">Fable 5.1</option>
                         <option value="claude-fable-5">Fable 5</option>
                       </select>
                     </div>
@@ -2124,6 +2129,7 @@
                         <option value="haiku">Haiku</option>
                         <option value="sonnet">Sonnet</option>
                         <option value="opus">Opus</option>
+                        <option value="claude-fable-5-1">Fable 5.1</option>
                         <option value="claude-fable-5">Fable 5</option>
                       </select>
                     </div>

--- a/src/web/public/settings-ui.js
+++ b/src/web/public/settings-ui.js
@@ -855,6 +855,7 @@ Object.assign(CodemanApp.prototype, {
         card.setAttribute('role', 'radio');
         card.dataset.value = opt.value;
         if (opt.dataset.ctx === '1') card.dataset.ctx = '1';
+        if (opt.dataset.ctxDefault === '1') card.dataset.ctxDefault = '1';
         const top = document.createElement('span');
         top.className = 'set-mc-top';
         const name = document.createElement('span');
@@ -869,10 +870,10 @@ Object.assign(CodemanApp.prototype, {
         meta.className = 'set-mc-meta';
         meta.textContent = opt.dataset.meta || '';
         card.appendChild(meta);
-        if (opt.dataset.ctx === '1') {
+        if (opt.dataset.ctx === '1' || opt.dataset.ctxDefault === '1') {
           const ctx = document.createElement('span');
           ctx.className = 'set-mc-ctx';
-          ctx.textContent = '1M capable';
+          ctx.textContent = opt.dataset.ctxDefault === '1' ? '1M included' : '1M capable';
           card.appendChild(ctx);
         }
         card.addEventListener('click', () => {
@@ -903,27 +904,38 @@ Object.assign(CodemanApp.prototype, {
     const grid = document.getElementById('appSettingsModelCards');
     if (!select || !grid) return;
     const base = this._settingsModelBase || '';
-    let capable = false;
+    let switchable = false;
+    let defaultContext = false;
     grid.querySelectorAll('.set-modelcard').forEach(card => {
       const on = card.dataset.value === base;
       card.classList.toggle('selected', on);
       card.setAttribute('aria-checked', on ? 'true' : 'false');
-      if (on) capable = card.dataset.ctx === '1';
+      if (on) {
+        switchable = card.dataset.ctx === '1';
+        defaultContext = card.dataset.ctxDefault === '1';
+      }
     });
-    const ctxOn = !!document.getElementById('appSettingsOpusContext1m')?.checked;
-    select.value = base && capable && ctxOn ? `${base}[1m]` : base;
-    // A model with no 1M variant makes the switch inert; say so instead of
-    // leaving a toggle that looks like it does something.
+    const contextSwitch = document.getElementById('appSettingsOpusContext1m');
+    // Fable 5.1's 1M window is part of the model, not a `[1m]` variant. Show
+    // that truthfully while keeping the older models' switchable variants.
+    if (defaultContext && contextSwitch) contextSwitch.checked = true;
+    if (contextSwitch) contextSwitch.disabled = !!base && !switchable;
+    const ctxOn = !!contextSwitch?.checked;
+    select.value = base && switchable && ctxOn ? `${base}[1m]` : base;
+    // A model with no switchable 1M variant makes the toggle inert; distinguish
+    // models that simply lack 1M from Fable 5.1, where 1M is always included.
     const row = document.getElementById('appSettingsContextRow');
     const desc = document.getElementById('appSettingsContextDesc');
-    const inert = !!base && !capable;
+    const inert = !!base && !switchable;
     row?.classList.toggle('set-row-disabled', inert);
     if (desc) {
-      desc.textContent = inert
-        ? 'The selected model has no 1M variant.'
-        : base
-          ? 'Available for Fable 5, Opus and Opus 4.6.'
-          : 'With no model pinned, this starts new sessions on Opus with a 1M window.';
+      desc.textContent = defaultContext
+        ? 'Fable 5.1 includes a 1M context window by default.'
+        : inert
+          ? 'The selected model has no 1M variant.'
+          : base
+            ? 'Available for Fable 5, Opus and Opus 4.6.'
+            : 'With no model pinned, this starts new sessions on Opus with a 1M window.';
     }
   },
 

--- a/test/app-settings-structure.test.ts
+++ b/test/app-settings-structure.test.ts
@@ -127,6 +127,17 @@ describe('App Settings modal structure', () => {
     expect(modal).toContain('id="appSettingsOpusContext1m"');
   });
 
+  it('models: exposes Fable 5.1 directly without inventing a [1m] variant', () => {
+    const modal = settingsModal();
+    const select = modal.match(/id="appSettingsClaudeModel"([\s\S]*?)<\/select>/)?.[1] ?? '';
+    expect(select).toContain('value="claude-fable-5-1"');
+    expect(select).toContain('data-ctx-default="1"');
+    expect(select).not.toContain('claude-fable-5-1[1m]');
+    expect(settingsUi).toContain("card.dataset.ctxDefault === '1'");
+    expect(settingsUi).toContain('Fable 5.1 includes a 1M context window by default.');
+    expect((modal.match(/value="claude-fable-5-1"/g) || []).length).toBe(6);
+  });
+
   it('has retired the modal-tab chrome everywhere, not just here', () => {
     // Session Options and Add Case moved onto this same `set-*` surface, so the
     // old tab classes have no users left. A reappearance means a modal drifted


### PR DESCRIPTION
## Summary
- add `claude-fable-5-1` to the new-session picker and task-routing selectors
- represent Fable 5.1 as a 1M-by-default model, without creating an invalid `[1m]` identifier
- document and structurally test the model-picker contract

## Validation
- `npm test -- test/app-settings-structure.test.ts`
- `npm run check:frontend-syntax`
- `npm run typecheck`
- `npm run build`