### PR TITLE
feat(models): offer Fable 5.1 in the model picker and task routing

### DIFF
--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -2028,6 +2028,8 @@
                   <div class="set-modelgrid" id="appSettingsModelCards" role="radiogroup" aria-label="Model for new Claude sessions" data-search="model opus sonnet haiku fable claude"></div>
                   <select id="appSettingsClaudeModel" class="set-select set-field-hidden" aria-hidden="true" tabindex="-1">
                     <option value="" data-meta="Whatever the CLI picks">Default (CLI setting)</option>
+                    <option value="claude-fable-5-1" data-meta="Latest" data-base="claude-fable-5-1" data-ctx="1">Fable 5.1</option>
+                    <option value="claude-fable-5-1[1m]" data-variant="1m" data-base="claude-fable-5-1">Fable 5.1 (1M context)</option>
                     <option value="claude-fable-5" data-meta="Most powerful" data-base="claude-fable-5" data-ctx="1">Fable 5</option>
                     <option value="claude-fable-5[1m]" data-variant="1m" data-base="claude-fable-5">Fable 5 (1M context)</option>
                     <option value="opus" data-meta="Most capable" data-base="opus" data-ctx="1">Opus</option>
@@ -2040,7 +2042,7 @@
                   <div class="set-row" id="appSettingsContextRow" data-search="1m context window opus long">
                     <div class="set-row-text">
                       <span class="set-row-label">1M context window</span>
-                      <span class="set-row-desc" id="appSettingsContextDesc">Available for Fable 5, Opus and Opus 4.6.</span>
+                      <span class="set-row-desc" id="appSettingsContextDesc">Available for Fable 5.1, Fable 5, Opus and Opus 4.6.</span>
                     </div>
                     <label class="switch switch-sm"><input type="checkbox" id="appSettingsOpusContext1m"><span class="slider"></span></label>
                   </div>
@@ -2080,6 +2082,7 @@
                     </div>
                     <select id="appSettingsDefaultModel" class="set-select">
                       <option value="">Default (CLI default)</option>
+                      <option value="claude-fable-5-1">Fable 5.1 (Latest)</option>
                       <option value="claude-fable-5">Fable 5 (Most powerful)</option>
                       <option value="opus">Opus (Most capable)</option>
                       <option value="sonnet">Sonnet (Balanced)</option>
@@ -2094,6 +2097,7 @@
                         <option value="haiku">Haiku</option>
                         <option value="sonnet">Sonnet</option>
                         <option value="opus">Opus</option>
+                        <option value="claude-fable-5-1">Fable 5.1</option>
                         <option value="claude-fable-5">Fable 5</option>
                       </select>
                     </div>
@@ -2104,6 +2108,7 @@
                         <option value="haiku">Haiku</option>
                         <option value="sonnet">Sonnet</option>
                         <option value="opus">Opus</option>
+                        <option value="claude-fable-5-1">Fable 5.1</option>
                         <option value="claude-fable-5">Fable 5</option>
                       </select>
                     </div>
@@ -2114,6 +2119,7 @@
                         <option value="haiku">Haiku</option>
                         <option value="sonnet">Sonnet</option>
                         <option value="opus">Opus</option>
+                        <option value="claude-fable-5-1">Fable 5.1</option>
                         <option value="claude-fable-5">Fable 5</option>
                       </select>
                     </div>
@@ -2124,6 +2130,7 @@
                         <option value="haiku">Haiku</option>
                         <option value="sonnet">Sonnet</option>
                         <option value="opus">Opus</option>
+                        <option value="claude-fable-5-1">Fable 5.1</option>
                         <option value="claude-fable-5">Fable 5</option>
                       </select>
                     </div>

--- a/src/web/public/settings-ui.js
+++ b/src/web/public/settings-ui.js
@@ -922,7 +922,7 @@ Object.assign(CodemanApp.prototype, {
       desc.textContent = inert
         ? 'The selected model has no 1M variant.'
         : base
-          ? 'Available for Fable 5, Opus and Opus 4.6.'
+          ? 'Available for Fable 5.1, Fable 5, Opus and Opus 4.6.'
           : 'With no model pinned, this starts new sessions on Opus with a 1M window.';
     }
   },

--- a/test/app-settings-structure.test.ts
+++ b/test/app-settings-structure.test.ts
@@ -120,11 +120,29 @@ describe('App Settings modal structure', () => {
     const select = modal.match(/id="appSettingsClaudeModel"([\s\S]*?)<\/select>/)?.[1] ?? '';
     // The cards render the base models; the [1m] rows exist so that base + the
     // context switch can compose back into a real claudeModel value.
-    for (const value of ['opus[1m]', 'claude-fable-5[1m]', 'claude-opus-4-6[1m]']) {
+    for (const value of ['opus[1m]', 'claude-fable-5[1m]', 'claude-fable-5-1[1m]', 'claude-opus-4-6[1m]']) {
       expect(select).toContain(`value="${value}"`);
     }
     expect(select).toContain('data-ctx="1"');
     expect(modal).toContain('id="appSettingsOpusContext1m"');
+  });
+
+  it('models: offers Fable 5.1 as a card and to task routing', () => {
+    const modal = settingsModal();
+    const select = modal.match(/id="appSettingsClaudeModel"([\s\S]*?)<\/select>/)?.[1] ?? '';
+    // The cards are built from these options, so data-ctx is what keeps the 1M
+    // switch live for the model rather than greying the row out.
+    expect(select).toMatch(/value="claude-fable-5-1"[^>]*data-ctx="1"/);
+    for (const id of [
+      'appSettingsDefaultModel',
+      'appSettingsModelExplore',
+      'appSettingsModelImplement',
+      'appSettingsModelTest',
+      'appSettingsModelReview',
+    ]) {
+      const routing = modal.match(new RegExp(`id="${id}"([\\s\\S]*?)</select>`))?.[1] ?? '';
+      expect(routing, `${id} does not offer Fable 5.1`).toContain('value="claude-fable-5-1"');
+    }
   });
 
   it('has retired the modal-tab chrome everywhere, not just here', () => {


### PR DESCRIPTION
## What this is

App Settings → Models lets you pin the model new Claude sessions start on. The
picker offered Fable 5, Opus, Opus 4.6, Sonnet and Haiku, but not **Fable 5.1**,
even though Claude Code has shipped it for a while: `claude-fable-5-1` is in the
CLI's baked-in model catalog (display name "Fable 5.1", June 2026 knowledge
cutoff). Pinning it meant editing a case's `.claude/settings.local.json` by hand.

This adds it to the picker and to the Task routing selects.

## How

Fable 5.1 is added **exactly the way Fable 5 already is**, and that is the whole
point of the shape of this diff:

- a base `<option value="claude-fable-5-1" … data-ctx="1">` in the hidden
  `#appSettingsClaudeModel` select, plus its `claude-fable-5-1[1m]` companion row
- `claude-fable-5-1` in Default-for-tasks and the four per-agent-type selects
  (Explore / Implement / Test / Review)

The card grid and the "1M context window" switch are built *from* those options
(`_buildModelCards` folds the `[1m]` rows away and `data-ctx="1"` is what keeps
the switch live), so **no settings-ui.js logic changes**: the card appears with
the "1M capable" badge, and base + switch compose back into
`claude-fable-5-1[1m]`. The only JS edit is one description string that lists
which models the switch applies to.

Both `claude-fable-5-1` and `claude-fable-5-1[1m]` are accepted by the CLI —
verified by running each through `claude --model … -p` and confirming neither
prints the `unrecognized_model` warning that a made-up id does.

## What this deliberately does not claim

It would be tempting to present Fable 5.1 as "1M by default" and leave the switch
as a Fable-5-only affordance. That distinction does not exist: the CLI catalog
marks **both** fable entries `native_1m: !0` with a `1e6` window. Giving 5.1 an
always-on window while 5 stays switchable would encode a difference the models do
not have, so 5.1 is treated identically to its sibling.

## Verification

- `npm test -- test/app-settings-structure.test.ts` — 9 passed. The existing 1M
  test now also pins `claude-fable-5-1[1m]`, and a new test asserts the base
  option carries `data-ctx="1"` and that all five routing selects offer the model.
- `npm run check:frontend-syntax`, `npm run check:public-assets` — pass.
- Real browser (Playwright against a server booted from this branch on an
  isolated `CODEMAN_INSTANCE`, so it could not touch live sessions):
  - the Fable 5.1 card renders first in the grid, labelled "Latest", with the
    "1M CAPABLE" badge, and the grid layout is unchanged
  - clicking it sets the select to `claude-fable-5-1`, leaves the context row
    enabled, and updates the description
  - flipping the 1M switch composes `claude-fable-5-1[1m]`
  - all five routing selects contain the option
  - Save → reload → reopen round-trips: card still selected, switch still on,
    select still `claude-fable-5-1[1m]`


## Notes

No changeset: the release flow writes one at version time.
