### PR TITLE
fix(mobile): lift the iOS Safari toolbar by the measured chrome overlap

### DIFF
--- a/src/web/public/mobile-handlers.js
+++ b/src/web/public/mobile-handlers.js
@@ -148,6 +148,13 @@ const MobileDetection = {
     if (typeof KeyboardHandler !== 'undefined' && KeyboardHandler.keyboardVisible) return;
     const vh = window.visualViewport?.height || window.innerHeight;
     document.documentElement.style.setProperty('--app-height', `${vh}px`);
+    // How far the layout viewport (which anchors position: fixed) extends below
+    // the visual viewport, i.e. behind the browser's bottom bar. 0 on iPhone
+    // Safari, where fixed elements already stop above the bar; the overlap
+    // where they do not. mobile.css lifts the toolbar by this rather than by
+    // (100vh - --app-height), which on iPhone measures the collapsible chrome
+    // instead and left an empty band between the toolbar and the bar.
+    document.documentElement.style.setProperty('--chrome-overlap', `${Math.max(0, window.innerHeight - vh)}px`);
   },
 
   /** Initialize mobile detection and set up resize listener */

--- a/src/web/public/mobile.css
+++ b/src/web/public/mobile.css
@@ -471,11 +471,11 @@ html.mobile-init .file-browser-panel {
     padding-bottom: calc(40px + var(--safe-area-bottom));
   }
 
-  /* iOS Safari: toolbar is pushed up by (100vh - --app-height) to clear the
-     browser's bottom bar. Match that offset in main's padding so the terminal
-     doesn't extend behind the toolbar. */
+  /* iOS Safari: the toolbar is lifted by --chrome-overlap where the browser's
+     bottom bar would otherwise cover it. Match that offset in main's padding so
+     the terminal doesn't extend behind the toolbar. */
   .ios-device.safari-browser .main {
-    padding-bottom: calc(40px + var(--safe-area-bottom) + (100vh - var(--app-height, 100vh)));
+    padding-bottom: calc(40px + var(--safe-area-bottom) + var(--chrome-overlap, 0px));
   }
 
   .header-right {
@@ -780,11 +780,14 @@ html.mobile-init .file-browser-panel {
     will-change: transform;
   }
 
-  /* iOS Safari with tab bar: position: fixed uses the layout viewport which
-     extends behind the browser chrome. Offset the toolbar upward by the delta
-     between 100vh (layout) and --app-height (visual). */
+  /* iOS Safari: where position: fixed anchors to a layout viewport that
+     extends behind the browser's bottom bar, lift the toolbar by that overlap.
+     --chrome-overlap is innerHeight minus the visual viewport height, set in
+     mobile-handlers.js. On iPhone Safari it is 0 because fixed elements already
+     stop above the bar; the previous (100vh - --app-height) lift measured the
+     collapsible chrome instead and left an empty band above the bar. */
   .ios-device.safari-browser .toolbar {
-    bottom: calc(var(--safe-area-bottom) + (100vh - var(--app-height, 100vh)));
+    bottom: calc(var(--safe-area-bottom) + var(--chrome-overlap, 0px));
   }
 
   /* When keyboard is visible the JS translateY already accounts for the full


### PR DESCRIPTION
Fixes #391.

## Problem

With the phone layout active on iPhone Safari there is an empty band of about 40 CSS px between the bottom toolbar and Safari's bottom bar whenever the bar is expanded, and the terminal is padded by the same amount. The phone block lifts the toolbar by `(100vh - var(--app-height))` on iOS Safari to clear a bar that `position: fixed` elements were assumed to sit behind. On iPhone Safari they already stop above it; `100vh` is the large viewport with the bar collapsed and `--app-height` is the visual viewport with it expanded, so the expression measures the bar's collapsible height instead of an overlap.

## Change

`updateAppHeight()` in `mobile-handlers.js` now also sets `--chrome-overlap` to `innerHeight - visualViewport.height`, the distance the layout viewport that anchors fixed elements extends past the visible area. The two rules in `mobile.css` (`.ios-device.safari-browser .toolbar` and `.ios-device.safari-browser .main`) use that variable in place of `100vh - --app-height`. On iPhone Safari the value is 0, so the toolbar meets the bar; on any browser where fixed elements really do land behind the chrome it equals the overlap, so the lift is kept there. The keyboard-visible rules, which already override the toolbar offset, are unchanged, and `updateAppHeight()` already runs on visual viewport resize and after the keyboard closes, so the value tracks the bar collapsing and expanding.

Independent of #390 (applies cleanly on master), but on a 440pt phone the phone block only matches once #390 is in, so the device check below ran with both.

## Verification

- `npm run check:frontend-syntax` and `npm run format:check`: pass
- `npm test` on this commit stacked on #390: 351 files passed, 1 skipped; 6755 tests passed, 12 skipped
- Playwright WebKit with the iPhone descriptor at 440 to 600px: no console errors, tiers unchanged (headless WebKit has no browser bar, so it cannot show the band itself)
- Real device, iPhone 17 Pro Max, Safari, 100% zoom: toolbar sits directly on Safari's bar at rest, toolbar and accessory bar sit directly above the keyboard when it is open, the toolbar stays flush while the bar collapses and expands on scroll, and the prompt and status lines stay visible above the toolbar
