### PR TITLE
fix(terminal): trap Ctrl+Z in non-shell sessions to prevent accidental suspend

### DIFF
--- a/src/web/public/panels-ui.js
+++ b/src/web/public/panels-ui.js
@@ -2314,6 +2314,27 @@ Object.assign(CodemanApp.prototype, {
         return;
       }
 
+      // Ctrl+Z (SIGTSTP/job-control suspend): a teammate/subagent pane is always
+      // running an agent CLI (Task-tool dispatched, never a plain shell), so
+      // unlike the main terminal's mode-gated trap this one is unconditional.
+      // Mirrors the main terminal's guard in terminal-ui.js's
+      // attachCustomKeyEventHandler — case-insensitive so Caps Lock (which
+      // flips ev.key to 'Z' without setting shiftKey) can't slip a suspend past it.
+      terminal.attachCustomKeyEventHandler((ev) => {
+        if (
+          ev.type === 'keydown' &&
+          ev.key.toLowerCase() === 'z' &&
+          ev.ctrlKey &&
+          !ev.altKey &&
+          !ev.metaKey &&
+          !ev.shiftKey
+        ) {
+          ev.preventDefault();
+          return false;
+        }
+        return true;
+      });
+
       // Wait for terminal renderer to fully initialize before any writes.
       // xterm.js needs a few frames after open() before write() is safe.
       setTimeout(() => {

--- a/src/web/public/terminal-ui.js
+++ b/src/web/public/terminal-ui.js
@@ -363,6 +363,29 @@ Object.assign(CodemanApp.prototype, {
         return false;
       }
 
+      // Ctrl+Z (SIGTSTP/job-control suspend): in a plain shell session this is the
+      // user's own job-control tool (suspend a foreground command, `fg` it back) —
+      // leave it alone. In every other mode (claude/omp/pi/codex/... — Ink/TUI apps
+      // that normally run in raw mode with ISIG off, so ^Z is usually inert there
+      // already) suspending the CLI stops an unattended agent loop dead with no
+      // visible output — the same failure shape as an XOFF freeze. Swallow it
+      // before xterm can send \x1a into the PTY rather than relying on every CLI's
+      // raw-mode state holding at every instant (startup, raw-mode toggles, etc).
+      if (
+        ev.type === 'keydown' &&
+        ev.key.toLowerCase() === 'z' &&
+        ev.ctrlKey &&
+        !ev.altKey &&
+        !ev.metaKey &&
+        !ev.shiftKey
+      ) {
+        const activeCtrlZSession = this.activeSessionId ? this.sessions.get(this.activeSessionId) : null;
+        if (activeCtrlZSession && activeCtrlZSession.mode !== 'shell') {
+          ev.preventDefault();
+          return false;
+        }
+      }
+
       // Shift+Enter / Ctrl+Enter: insert newline for multi-line input.
       // xterm.js sends plain \r for all Enter variants, so Claude Code (Ink) can't
       // distinguish them. We use tmux send-keys -H to send a line feed byte (0x0a)


### PR DESCRIPTION
## Summary
- Ctrl+Z (SIGTSTP) suspends the foreground job on the pane's tty. In a plain shell session that's normal job control, but in claude/omp/pi/codex/etc. sessions it silently stops an unattended agent loop dead — same failure shape as an XOFF freeze, just via job control instead of tty flow control.
- Swallowed client-side in `attachCustomKeyEventHandler`, mode-gated so shell sessions keep normal Ctrl+Z job control (suspend/`fg`) untouched. Mirrors the existing Ctrl+V/Ctrl+Backspace interception pattern in the same handler.
- Case-insensitive key match — Caps Lock flips `ev.key` to `'Z'` without setting `shiftKey`, so a plain `=== 'z'` check let the exact suspend keystroke this exists to catch slip through.
- Also covers subagent/teammate terminal windows (`panels-ui.js`'s `initTeammateTerminal`), which render a separate xterm instance with no custom key handler at all and always run an agent CLI (never a shell), so the trap there is unconditional.

## Test plan
- [x] `npm run check:frontend-syntax` — both changed files parse cleanly
- [x] Existing terminal key-handling tests pass (`terminal-copy-selection.test.ts`, `shortcut-registry-overlay.test.ts`)
- [x] Live-tested: Ctrl+S/Ctrl+Q flow control unaffected, Ctrl+Z verified inert in a claude session and still suspends normally in a shell session
- [x] Reviewed twice via `/code-review --level high` (including the Caps Lock finding that shaped this diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
